### PR TITLE
feat: incorporate data into the Product Overview widget

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -5,5 +5,6 @@
   <body>
     <div id="root"></div>
     <script src="bundle.js" ></script>
+    <script src="https://kit.fontawesome.com/f3170e7d8f.js" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
@@ -1,23 +1,34 @@
 // The 'main' component that keeps all of the pieces of the gallery together
 
 // Import stuff
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ImageGalleryContainer } from '../StyledComponents/Containers.jsx';
 import { ImageThumbnails, Thumbnail } from '../StyledComponents/ImageGallery/ImageThumbnails.jsx';
-import MainImage from '../StyledComponents/ImageGallery/MainImage.jsx';
+import MainImage from './MainImage.jsx';
 
 // The component
 var Gallery = (props) => {
 
+  const [imageThumbnails, setImageThumbnails] = useState([]);
+  const [chosenImageUrl, setChosenImageUrl] = useState('');
+
+  // When the chosenStyle state is updated, update this component's hooks accordingly
+  useEffect(() => {
+    if (props.chosenStyle.photos) {
+      setImageThumbnails(props.chosenStyle.photos);
+      setChosenImageUrl(props.chosenStyle.photos[0].url)
+    }
+  }, [props.chosenStyle])
+
   return (
-    <div>
-      <ImageGalleryContainer>
-        <ImageThumbnails>
-          <Thumbnail></Thumbnail><Thumbnail></Thumbnail><Thumbnail></Thumbnail>
-        </ImageThumbnails>
-        <MainImage></MainImage>
-      </ImageGalleryContainer>
-    </div>
+
+    <ImageGalleryContainer>
+      <ImageThumbnails>
+        <Thumbnail></Thumbnail><Thumbnail></Thumbnail><Thumbnail></Thumbnail>
+      </ImageThumbnails>
+      <MainImage chosenImageUrl={chosenImageUrl} />
+    </ImageGalleryContainer>
+
   );
 }
 

--- a/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
@@ -3,8 +3,8 @@
 // Import stuff
 import React, { useState, useEffect } from 'react';
 import { ImageGalleryContainer } from '../StyledComponents/Containers.jsx';
-import { ImageThumbnails, Thumbnail } from '../StyledComponents/ImageGallery/ImageThumbnails.jsx';
 import MainImage from './MainImage.jsx';
+import ThumbnailList from './ThumbnailList.jsx';
 
 // The component
 var Gallery = (props) => {
@@ -23,9 +23,7 @@ var Gallery = (props) => {
   return (
 
     <ImageGalleryContainer>
-      <ImageThumbnails>
-        <Thumbnail></Thumbnail><Thumbnail></Thumbnail><Thumbnail></Thumbnail>
-      </ImageThumbnails>
+      <ThumbnailList imageThumbnails={imageThumbnails} />
       <MainImage chosenImageUrl={chosenImageUrl} />
     </ImageGalleryContainer>
 

--- a/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
@@ -1,0 +1,20 @@
+// The main image-- it can expand!
+
+// Import stuff
+import React, { useState } from 'react';
+import { Image, DefaultView, ExpandedView } from '../StyledComponents/ImageGallery/MainImage.jsx';
+
+// The component
+var MainImage = (props) => {
+
+  const [view, setView] = useState('default');
+
+  return (
+    <DefaultView>
+      <Image src={props.chosenImageUrl} />
+    </DefaultView>
+  );
+}
+
+// Export it
+export default MainImage;

--- a/client/src/Components/ProductOverview/ImageGallery/Thumbnail.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/Thumbnail.jsx
@@ -1,0 +1,16 @@
+// The Thumbnail component
+// Import stuff
+import React, { useEffect } from 'React';
+import { ThumbnailImage } from '../StyledComponents/ImageGallery/ImageThumbnails.jsx';
+
+// The list component itself
+var Thumbnail = (props) => {
+
+
+
+  return (
+    <ThumbnailImage src={props.thumbnail_url} />
+  );
+}
+
+export default Thumbnail;

--- a/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
@@ -9,12 +9,10 @@ import Thumbnail from './Thumbnail.jsx';
 var ThumbnailList = (props) => {
 
   // const [chosenThumbnail, setChosenThumbnail] = useState('');
-  // An index to use as the keys of the thumbnails
-  var index = 0;
 
   return (
     <ImageThumbnails>
-      {props.imageThumbnails.map((thumbnail) => {
+      {props.imageThumbnails.map((thumbnail, index = 0) => {
         return (
           <Thumbnail thumbnail_url={thumbnail.thumbnail_url} key={index++} />
           // If the thumbnail is the chosen one, render a bar under it to indicate that it's the chosen one

--- a/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
@@ -9,12 +9,14 @@ import Thumbnail from './Thumbnail.jsx';
 var ThumbnailList = (props) => {
 
   // const [chosenThumbnail, setChosenThumbnail] = useState('');
+  // An index to use as the keys of the thumbnails
+  var index = 0;
 
   return (
     <ImageThumbnails>
       {props.imageThumbnails.map((thumbnail) => {
         return (
-          <Thumbnail thumbnail_url={thumbnail.thumbnail_url} />
+          <Thumbnail thumbnail_url={thumbnail.thumbnail_url} key={index++} />
           // If the thumbnail is the chosen one, render a bar under it to indicate that it's the chosen one
         );
       })}

--- a/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
@@ -1,0 +1,25 @@
+// The List of Thumbnail components
+
+// Import stuff
+import React, { useState, useEffect } from 'React';
+import { ImageThumbnails } from '../StyledComponents/ImageGallery/ImageThumbnails.jsx';
+import Thumbnail from './Thumbnail.jsx';
+
+// The list component itself
+var ThumbnailList = (props) => {
+
+  // const [chosenThumbnail, setChosenThumbnail] = useState('');
+
+  return (
+    <ImageThumbnails>
+      {props.imageThumbnails.map((thumbnail) => {
+        return (
+          <Thumbnail thumbnail_url={thumbnail.thumbnail_url} />
+          // If the thumbnail is the chosen one, render a bar under it to indicate that it's the chosen one
+        );
+      })}
+    </ImageThumbnails>
+  );
+}
+
+export default ThumbnailList;

--- a/client/src/Components/ProductOverview/Overview.jsx
+++ b/client/src/Components/ProductOverview/Overview.jsx
@@ -8,6 +8,7 @@ var Overview = (props) => {
 
   const [product, setProduct] = useState({});
   const [styles, setStyles] = useState([]);
+  const [chosenStyle, setChosenStyle] = useState({});
   const [reviews, setReviews] = useState({});
 
   // Upon component mounting, send a GET request and get all the relevant data (this may need to be refactored if the team decides to house all client-side request handling in the main App file)
@@ -17,7 +18,7 @@ var Overview = (props) => {
     axios.get('/snuggie/products', { params: { product_id: 40344 } }) // Right now, we have a placeholder for the specific product
       // Then set the products state
       .then((results) => {
-        setProduct(results.data);
+        return setProduct(results.data);
       })
       // Send axios request to get all styles
       .then(() => {
@@ -25,7 +26,7 @@ var Overview = (props) => {
       })
       // Then set the styles state
       .then((results) => {
-        setStyles(results.data.results);
+        return setStyles(results.data.results);
       })
       // Send axios request to get all the review data that is relevant for the specific product
       // Then set the reviews state
@@ -37,11 +38,11 @@ var Overview = (props) => {
   return (
     <div>
       <ProductOverviewContainer>
-        <Gallery product={product} styles={styles} />
-        <Information product={product} styles={styles} reveiws={reviews} />
+        <Gallery product={product} styles={styles} chosenStyle={chosenStyle} />
+        <Information product={product} styles={styles} chosenStyle={chosenStyle}  setChosenStyle={setChosenStyle} reveiws={reviews} />
       </ProductOverviewContainer>
       <ProductInformationDescription>
-        Product Information
+        {product.description}
       </ProductInformationDescription>
     </div>
   );

--- a/client/src/Components/ProductOverview/Overview.jsx
+++ b/client/src/Components/ProductOverview/Overview.jsx
@@ -38,7 +38,7 @@ var Overview = (props) => {
   return (
     <div>
       <ProductOverviewContainer>
-        <Gallery product={product} styles={styles} chosenStyle={chosenStyle} />
+        <Gallery chosenStyle={chosenStyle} />
         <Information product={product} styles={styles} chosenStyle={chosenStyle}  setChosenStyle={setChosenStyle} reveiws={reviews} />
       </ProductOverviewContainer>
       <ProductInformationDescription>

--- a/client/src/Components/ProductOverview/Overview.jsx
+++ b/client/src/Components/ProductOverview/Overview.jsx
@@ -13,13 +13,26 @@ var Overview = (props) => {
   // Upon component mounting, send a GET request and get all the relevant data (this may need to be refactored if the team decides to house all client-side request handling in the main App file)
   useEffect(() => {
     console.log('HI!');
-    // Send axios request to get all products? or maybe just the specific one
-    // Then set the products state
-    // Send axios request to get all styles
-    // Then set the styles state
-    // Send axios request to get all the review data that is relevant for the specific product
-    // Then set the reviews state
-  });
+    // Send axios request to the specific product
+    axios.get('/snuggie/products', { params: { product_id: 40344 } }) // Right now, we have a placeholder for the specific product
+      // Then set the products state
+      .then((results) => {
+        setProduct(results.data);
+      })
+      // Send axios request to get all styles
+      .then(() => {
+        return axios.get('/snuggie/styles', { params: { product_id: 40344 } });
+      })
+      // Then set the styles state
+      .then((results) => {
+        setStyles(results.data.results);
+      })
+      // Send axios request to get all the review data that is relevant for the specific product
+      // Then set the reviews state
+      .catch((error) => {
+        console.log('An error occurred when initializing data received from server:', error);
+      });
+  }, []); // The second argument is an empty array, which makes it so that we only run the function once
 
   return (
     <div>

--- a/client/src/Components/ProductOverview/Overview.jsx
+++ b/client/src/Components/ProductOverview/Overview.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import { ProductOverviewContainer, ProductInformationDescription } from './StyledComponents/Containers.jsx';
 import Gallery from './ImageGallery/Gallery.jsx';
 import Information from './ProductInformation/Information.jsx';
@@ -8,6 +9,17 @@ var Overview = (props) => {
   const [product, setProduct] = useState({});
   const [styles, setStyles] = useState([]);
   const [reviews, setReviews] = useState({});
+
+  // Upon component mounting, send a GET request and get all the relevant data (this may need to be refactored if the team decides to house all client-side request handling in the main App file)
+  useEffect(() => {
+    console.log('HI!');
+    // Send axios request to get all products? or maybe just the specific one
+    // Then set the products state
+    // Send axios request to get all styles
+    // Then set the styles state
+    // Send axios request to get all the review data that is relevant for the specific product
+    // Then set the reviews state
+  });
 
   return (
     <div>

--- a/client/src/Components/ProductOverview/ProductInformation/Information.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/Information.jsx
@@ -28,7 +28,7 @@ var Information = (props) => {
       <div>{props.product.name}</div>
       <div>{props.chosenStyle.original_price /* Will have to do some math here and calculate the price (in case theres a sale) */}</div>
       <div>Style > {props.chosenStyle.name || "Selected Style"}</div>
-      <Styles styles={props.styles} chosenStyle={props.chosenStyle} />
+      <Styles styles={props.styles} chosenStyle={props.chosenStyle} setChosenStyle={props.setChosenStyle} />
       <CartButtons />
     </ProductInformationContainer>
   );

--- a/client/src/Components/ProductOverview/ProductInformation/Information.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/Information.jsx
@@ -1,7 +1,7 @@
 // The 'main' component that keeps all of the pieces of the Product Information together
 
 // Import stuff
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ProductInformationContainer } from '../StyledComponents/Containers.jsx';
 import OverviewStars from './OverviewStarRating.jsx';
 import Styles from './StyleSelector.jsx';
@@ -10,14 +10,27 @@ import CartButtons from './AddToCart.jsx';
 // The component
 var Information = (props) => {
 
+  const [chosenStyle, setChosenStyle] = useState({});
+  console.log(props.styles);
+
+  useEffect(() => {
+    // For each of the styles in the passed in styles prop, iterate until we find the default one and set that as the displayed style
+    for (let i = 0; i < props.styles.length; i++) {
+      if (props.styles[i]["default?"]) {
+        setChosenStyle(props.styles[i]);
+        break;
+      }
+    }
+  });
+
   return (
     <ProductInformationContainer>
       <OverviewStars />
-      <div>Category</div>
-      <div>Name</div>
-      <div>Price</div>
-      <div>Style > Selected Style</div>
-      <Styles />
+      <div>{props.product.category}</div>
+      <div>{props.product.name}</div>
+      <div>{chosenStyle.original_price /* Will have to do some math here and calculate the price (in case theres a sale) */}</div>
+      <div>Style > {chosenStyle.name}</div>
+      <Styles styles={props.styles || "Selected Style"} />
       <CartButtons />
     </ProductInformationContainer>
   );

--- a/client/src/Components/ProductOverview/ProductInformation/Information.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/Information.jsx
@@ -10,26 +10,24 @@ import CartButtons from './AddToCart.jsx';
 // The component
 var Information = (props) => {
 
-  const [chosenStyle, setChosenStyle] = useState({});
-  console.log(props.styles);
-
+  // Iterate and choose the default style whenever the style list changes (e.g. choose new product)
   useEffect(() => {
     // For each of the styles in the passed in styles prop, iterate until we find the default one and set that as the displayed style
     for (let i = 0; i < props.styles.length; i++) {
       if (props.styles[i]["default?"]) {
-        setChosenStyle(props.styles[i]);
+        props.setChosenStyle(props.styles[i]);
         break;
       }
     }
-  });
+  }, [props.styles]);
 
   return (
     <ProductInformationContainer>
       <OverviewStars />
       <div>{props.product.category}</div>
       <div>{props.product.name}</div>
-      <div>{chosenStyle.original_price /* Will have to do some math here and calculate the price (in case theres a sale) */}</div>
-      <div>Style > {chosenStyle.name}</div>
+      <div>{props.chosenStyle.original_price /* Will have to do some math here and calculate the price (in case theres a sale) */}</div>
+      <div>Style > {props.chosenStyle.name}</div>
       <Styles styles={props.styles || "Selected Style"} />
       <CartButtons />
     </ProductInformationContainer>

--- a/client/src/Components/ProductOverview/ProductInformation/Information.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/Information.jsx
@@ -27,8 +27,8 @@ var Information = (props) => {
       <div>{props.product.category}</div>
       <div>{props.product.name}</div>
       <div>{props.chosenStyle.original_price /* Will have to do some math here and calculate the price (in case theres a sale) */}</div>
-      <div>Style > {props.chosenStyle.name}</div>
-      <Styles styles={props.styles || "Selected Style"} />
+      <div>Style > {props.chosenStyle.name || "Selected Style"}</div>
+      <Styles styles={props.styles} />
       <CartButtons />
     </ProductInformationContainer>
   );

--- a/client/src/Components/ProductOverview/ProductInformation/Information.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/Information.jsx
@@ -28,7 +28,7 @@ var Information = (props) => {
       <div>{props.product.name}</div>
       <div>{props.chosenStyle.original_price /* Will have to do some math here and calculate the price (in case theres a sale) */}</div>
       <div>Style > {props.chosenStyle.name || "Selected Style"}</div>
-      <Styles styles={props.styles} />
+      <Styles styles={props.styles} chosenStyle={props.chosenStyle} />
       <CartButtons />
     </ProductInformationContainer>
   );

--- a/client/src/Components/ProductOverview/ProductInformation/StyleSelector.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/StyleSelector.jsx
@@ -3,7 +3,8 @@
 // Import stuff
 import React, { useState } from 'react';
 import { StyleThumbnailContainer } from '../StyledComponents/Containers.jsx';
-import StyleThumbnail from '../StyledComponents/ProductInformation/StyleThumbnail.jsx';
+import { ChosenStyleContainer } from '../StyledComponents/Containers.jsx';
+import { StyleThumbnail, ChosenIcon } from '../StyledComponents/ProductInformation/StyleThumbnail.jsx';
 
 // The component
 var Styles = (props) => {
@@ -13,8 +14,17 @@ var Styles = (props) => {
       <StyleThumbnailContainer>
         {/* For each style in the styles prop, render a thumbnail of the first image of the style */}
         {props.styles.map((style) => {
-          // Add something here such that if the style is the chosen one, make it have a special border
-          return <StyleThumbnail src={style.photos[0].thumbnail_url}></StyleThumbnail>
+          // If the style is the chosen one, render a special thumbnail (it has a border around it that indicates that it's the selected one)
+          if (style.style_id === props.chosenStyle.style_id) {
+            return (
+              <ChosenStyleContainer>
+                <ChosenIcon src="https://media.istockphoto.com/photos/green-checkmark-picture-id503451933?k=20&m=503451933&s=612x612&w=0&h=5X5bKop-YhMgPI5YgPOvroGXlbRX1shmtsGUM948cZo=" ></ChosenIcon>
+                <StyleThumbnail src={style.photos[0].thumbnail_url} ></StyleThumbnail>
+              </ChosenStyleContainer>
+            );
+          }
+          // Else just render the thumbnail without the special border
+          return (<StyleThumbnail src={style.photos[0].thumbnail_url} ></StyleThumbnail>);
         })}
       </StyleThumbnailContainer>
     </div>

--- a/client/src/Components/ProductOverview/ProductInformation/StyleSelector.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/StyleSelector.jsx
@@ -11,10 +11,11 @@ var Styles = (props) => {
   return (
     <div>
       <StyleThumbnailContainer>
-        <StyleThumbnail src="https://is2-ssl.mzstatic.com/image/thumb/qJ7YKor8fRTpFepcEyMzJQ/1200x675mf.jpg"></StyleThumbnail>
-        <StyleThumbnail src="https://external-preview.redd.it/_ysVY46s4W2COAnR769iuSMM-bTPFrhH_YmJS2WeDnw.jpg?auto=webp&s=ab4dad2ccf5caf76fa1f8107e6a727295862ec45"></StyleThumbnail>
-        <StyleThumbnail src="https://pbs.twimg.com/profile_images/676614171849453568/AZd1Bh-s_400x400.png"></StyleThumbnail>
-        <StyleThumbnail src="https://i.ytimg.com/vi/gBCEJBOwewg/hqdefault.jpg"></StyleThumbnail>
+        {/* For each style in the styles prop, render a thumbnail of the first image of the style */}
+        {props.styles.map((style) => {
+          // Add something here such that if the style is the chosen one, make it have a special border
+          return <StyleThumbnail src={style.photos[0].thumbnail_url}></StyleThumbnail>
+        })}
       </StyleThumbnailContainer>
     </div>
   );

--- a/client/src/Components/ProductOverview/ProductInformation/StyleSelector.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/StyleSelector.jsx
@@ -18,7 +18,7 @@ var Styles = (props) => {
           if (style.style_id === props.chosenStyle.style_id) {
             return (
               <ChosenStyleContainer>
-                <ChosenIcon src="https://media.istockphoto.com/photos/green-checkmark-picture-id503451933?k=20&m=503451933&s=612x612&w=0&h=5X5bKop-YhMgPI5YgPOvroGXlbRX1shmtsGUM948cZo=" ></ChosenIcon>
+                <ChosenIcon className="fa-solid fa-check"></ChosenIcon>
                 <StyleThumbnail src={style.photos[0].thumbnail_url} ></StyleThumbnail>
               </ChosenStyleContainer>
             );

--- a/client/src/Components/ProductOverview/ProductInformation/StyleSelector.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/StyleSelector.jsx
@@ -19,12 +19,12 @@ var Styles = (props) => {
             return (
               <ChosenStyleContainer>
                 <ChosenIcon className="fa-solid fa-check"></ChosenIcon>
-                <StyleThumbnail src={style.photos[0].thumbnail_url} ></StyleThumbnail>
+                <StyleThumbnail src={style.photos[0].thumbnail_url} onClick={() => {props.setChosenStyle(style)}} ></StyleThumbnail>
               </ChosenStyleContainer>
             );
           }
           // Else just render the thumbnail without the special border
-          return (<StyleThumbnail src={style.photos[0].thumbnail_url} ></StyleThumbnail>);
+          return (<StyleThumbnail src={style.photos[0].thumbnail_url} onClick={() => {props.setChosenStyle(style)}} ></StyleThumbnail>);
         })}
       </StyleThumbnailContainer>
     </div>

--- a/client/src/Components/ProductOverview/ProductInformation/StyleSelector.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/StyleSelector.jsx
@@ -17,14 +17,14 @@ var Styles = (props) => {
           // If the style is the chosen one, render a special thumbnail (it has a border around it that indicates that it's the selected one)
           if (style.style_id === props.chosenStyle.style_id) {
             return (
-              <ChosenStyleContainer>
-                <ChosenIcon className="fa-solid fa-check"></ChosenIcon>
-                <StyleThumbnail src={style.photos[0].thumbnail_url} onClick={() => {props.setChosenStyle(style)}} ></StyleThumbnail>
+              <ChosenStyleContainer key="ChosenStyleContainer" >
+                <ChosenIcon className="fa-solid fa-check" key="ChosenStyleIcon"></ChosenIcon>
+                <StyleThumbnail key={style.style_id} src={style.photos[0].thumbnail_url} onClick={() => {props.setChosenStyle(style)}} ></StyleThumbnail>
               </ChosenStyleContainer>
             );
           }
           // Else just render the thumbnail without the special border
-          return (<StyleThumbnail src={style.photos[0].thumbnail_url} onClick={() => {props.setChosenStyle(style)}} ></StyleThumbnail>);
+          return (<StyleThumbnail key={style.style_id} src={style.photos[0].thumbnail_url} onClick={() => {props.setChosenStyle(style)}} ></StyleThumbnail>);
         })}
       </StyleThumbnailContainer>
     </div>

--- a/client/src/Components/ProductOverview/StyledComponents/Containers.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/Containers.jsx
@@ -35,6 +35,11 @@ const StyleThumbnailContainer = styled.section`
   flex-wrap: wrap;
 `;
 
+// Container to hold the chosen Style Thumbnail and the icon that indicates that it's the chosen one
+const ChosenStyleContainer = styled.section`
+  position: relative;
+`;
+
 // Container for the size and count buttons in Product Information section
 const SizeAndCountContainer = styled.section`
   display: flex;
@@ -54,4 +59,4 @@ const ProductInformationDescription = styled.section`
 `;
 
 // Export the styled components
-export { ProductOverviewContainer, ImageGalleryContainer, ProductInformationContainer, ProductOverviewStarContainer, StyleThumbnailContainer, SizeAndCountContainer, AddToCartContainer, ProductInformationDescription };
+export { ProductOverviewContainer, ImageGalleryContainer, ProductInformationContainer, ProductOverviewStarContainer, StyleThumbnailContainer, ChosenStyleContainer, SizeAndCountContainer, AddToCartContainer, ProductInformationDescription };

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageThumbnails.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageThumbnails.jsx
@@ -11,11 +11,13 @@ const ImageThumbnails = styled.section`
 `;
 
 // An image thumbnail
-const Thumbnail = styled.img`
+const ThumbnailImage = styled.img`
+  object-fit: cover;
+  overflow: hidden;
   width: 50px;
   height: 50px;
   background-color: gray;
 `;
 
 // Export the styled components
-export { ImageThumbnails, Thumbnail };
+export { ImageThumbnails, ThumbnailImage };

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
@@ -3,12 +3,27 @@
 // Import any relevant methods from the styled-components library
 import styled from 'styled-components';
 
-// The Main Image
-const MainImage = styled.img`
+// The Main Image itself
+const Image = styled.img`
+  object-fit: cover;
+  overflow: hidden;
+`;
+
+// The Main Image, default view
+const DefaultView = styled.div`
+  display: flex;
+  justify-content: center;
   width: 300px;
   height: 300px;
   background-color: black;
 `;
 
+// The Main Image, expanded view
+const ExpandedView = styled.div`
+  width: 600px;
+  height: 300px;
+  background-color: black;
+`;
+
 // Export the styled components
-export default MainImage;
+export { Image, DefaultView, ExpandedView };

--- a/client/src/Components/ProductOverview/StyledComponents/ProductInformation/StyleThumbnail.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ProductInformation/StyleThumbnail.jsx
@@ -1,17 +1,28 @@
-// Product Overview Style Thumbnail styling
+// Product Overview Style Thumbnail and all related things styling
 
 // Import any relevant methods from the styled-components library
 import styled from 'styled-components';
 
-// The link labeled 'Read [#] Reviews'
+// The style thumbnail image for a style
 const StyleThumbnail = styled.img`
+  display: block;
   object-fit: fill;
   border: solid;
-  border-color: orange;
+  border-color: black;
   border-radius: 50%;
   width: 100px;
   height: 100px;
 `;
 
+// An icon that indicates that the thumbnail is the chosen one
+const ChosenIcon = styled.img`
+  position: absolute;
+  top: 7%;
+  right: 7%;
+  object-fit: fill;
+  width: 15px;
+  height: 15px;
+`;
+
 // Export the styled components
-export default StyleThumbnail;
+export { StyleThumbnail, ChosenIcon };

--- a/client/src/Components/ProductOverview/StyledComponents/ProductInformation/StyleThumbnail.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ProductInformation/StyleThumbnail.jsx
@@ -15,13 +15,18 @@ const StyleThumbnail = styled.img`
 `;
 
 // An icon that indicates that the thumbnail is the chosen one
-const ChosenIcon = styled.img`
+const ChosenIcon = styled.i`
   position: absolute;
-  top: 7%;
-  right: 7%;
+  top: 5%;
+  right: 5%;
   object-fit: fill;
   width: 15px;
   height: 15px;
+  background-color: white;
+  padding: 3px;
+  border: solid;
+  border-color: black;
+  border-radius: 50%;
 `;
 
 // Export the styled components


### PR DESCRIPTION
Various features detailed in the commit messages. Tl;dr:

- as a temporary measure (until we decide where to issue the client-side http requests), Product Overview widget issues requests to the server to retrieve (example) data
- the style selector renders relevant images based on the data retrieved
- clicking a style in the style selector changes the chosenStyle state of the product overview widget (implementation subject to change based on future discussions regarding App-wide state)
- the image gallery renders relevant images based on the data retrieved

Please review, time permitting.