### PR TITLE
bugfix: fix webpack warning

### DIFF
--- a/client/src/Components/ProductOverview/ImageGallery/Thumbnail.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/Thumbnail.jsx
@@ -1,6 +1,6 @@
 // The Thumbnail component
 // Import stuff
-import React, { useEffect } from 'React';
+import React, { useEffect } from 'react';
 import { ThumbnailImage } from '../StyledComponents/ImageGallery/ImageThumbnails.jsx';
 
 // The list component itself

--- a/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
@@ -1,7 +1,7 @@
 // The List of Thumbnail components
 
 // Import stuff
-import React, { useState, useEffect } from 'React';
+import React, { useState, useEffect } from 'react';
 import { ImageThumbnails } from '../StyledComponents/ImageGallery/ImageThumbnails.jsx';
 import Thumbnail from './Thumbnail.jsx';
 


### PR DESCRIPTION
bugfix: fix webpack warning (multiple modules with names that only differ in casing) by changing imports in ThumbnailList.jsx and Thumbnail.jsx from 'React' to 'react'