### PR TITLE
refactor: App.js to GET request product id on initial mount

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,15 +1,37 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import Overview from './Components/ProductOverview/Overview.jsx';
 import QnaIndex from './Components/QuestionsAndAnswers/QnaIndex.jsx';
 import RatingsAndReviewsIndex from './Components/RatingsAndReviews/RatingsAndReviewsIndex.jsx'
 import RInC from './Components/RelatedItemsAndComparison/RInCIndex.jsx';
 
 var App = () => {
+
+  // Hook for what specific product is being displayed
+  const [productId, setProductId] = useState();
+
+  // When App first mounts, send a GET request to the server to get the productId of the first product received
+  useEffect(() => {
+    // Send axios request to get all products
+    axios.get('/snuggie/products') // No query/parameters, so this endpoint returns ALL products
+      // Then get the specific product
+      .then((results) => {
+        console.log('ah', results);
+        return axios.get('/snuggie/products', { params: {product_id: results.data[0].id} });
+      })
+      // Then set the hook
+      .then((results) => {
+        setProductId(results.data.id);
+      })
+      .catch((error) => {
+        console.log('An error occurred when initializing data received from server:', error);
+      });
+  }, []); // Second argument being an empty array causes this instance of useEffect to only run once
+
   return(
     <div>
       <h1>Hi</h1>
-      <Overview />
+      <Overview productId={productId} setProductId={setProductId} />
       <br/>
       <RInC/>
       <br/>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,8 +7,9 @@ import RInC from './Components/RelatedItemsAndComparison/RInCIndex.jsx';
 
 var App = () => {
 
-  // Hook for what specific product is being displayed
+  // Hooks for what specific product is being displayed
   const [productId, setProductId] = useState();
+  const [chosenProduct, setChosenProduct] = useState({});
 
   // When App first mounts, send a GET request to the server to get the productId of the first product received
   useEffect(() => {
@@ -19,8 +20,9 @@ var App = () => {
         console.log('ah', results);
         return axios.get('/snuggie/products', { params: {product_id: results.data[0].id} });
       })
-      // Then set the hook
+      // Then set the hooks
       .then((results) => {
+        setChosenProduct(results.data);
         setProductId(results.data.id);
       })
       .catch((error) => {
@@ -30,8 +32,9 @@ var App = () => {
 
   return(
     <div>
-      <h1>Hi</h1>
-      <Overview productId={productId} setProductId={setProductId} />
+      <div>navbar</div>
+      <h1>ANNOUNCEMENTS GO HERE</h1>
+      <Overview productId={productId} chosenProduct={chosenProduct} />
       <br/>
       <RInC/>
       <br/>

--- a/client/src/Components/ProductOverview/Overview.jsx
+++ b/client/src/Components/ProductOverview/Overview.jsx
@@ -6,7 +6,6 @@ import Information from './ProductInformation/Information.jsx';
 
 var Overview = (props) => {
 
-  const [product, setProduct] = useState({});
   const [styles, setStyles] = useState([]);
   const [chosenStyle, setChosenStyle] = useState({});
   const [reviews, setReviews] = useState({});
@@ -15,16 +14,8 @@ var Overview = (props) => {
   useEffect(() => {
     console.log('HI!');
     if (props.productId) {
-      // Send axios request to the specific product
-      axios.get('/snuggie/products', { params: { product_id: props.productId } }) // Right now, we have a placeholder for the specific product
-        // Then set the products state
-        .then((results) => {
-          return setProduct(results.data);
-        })
-        // Send axios request to get all styles
-        .then(() => {
-          return axios.get('/snuggie/styles', { params: { product_id: props.productId } });
-        })
+      // Send axios request to get all styles
+      axios.get('/snuggie/styles', { params: { product_id: props.productId } })
         // Then set the styles state
         .then((results) => {
           return setStyles(results.data.results);
@@ -41,10 +32,10 @@ var Overview = (props) => {
     <div>
       <ProductOverviewContainer>
         <Gallery chosenStyle={chosenStyle} />
-        <Information product={product} styles={styles} chosenStyle={chosenStyle}  setChosenStyle={setChosenStyle} reveiws={reviews} />
+        <Information product={props.chosenProduct} styles={styles} chosenStyle={chosenStyle}  setChosenStyle={setChosenStyle} reviews={reviews} />
       </ProductOverviewContainer>
       <ProductInformationDescription>
-        {product.description}
+        {props.chosenProduct.description}
       </ProductInformationDescription>
     </div>
   );

--- a/client/src/Components/ProductOverview/Overview.jsx
+++ b/client/src/Components/ProductOverview/Overview.jsx
@@ -14,26 +14,28 @@ var Overview = (props) => {
   // Upon component mounting, send a GET request and get all the relevant data (this may need to be refactored if the team decides to house all client-side request handling in the main App file)
   useEffect(() => {
     console.log('HI!');
-    // Send axios request to the specific product
-    axios.get('/snuggie/products', { params: { product_id: 40344 } }) // Right now, we have a placeholder for the specific product
-      // Then set the products state
-      .then((results) => {
-        return setProduct(results.data);
-      })
-      // Send axios request to get all styles
-      .then(() => {
-        return axios.get('/snuggie/styles', { params: { product_id: 40344 } });
-      })
-      // Then set the styles state
-      .then((results) => {
-        return setStyles(results.data.results);
-      })
-      // Send axios request to get all the review data that is relevant for the specific product
-      // Then set the reviews state
-      .catch((error) => {
-        console.log('An error occurred when initializing data received from server:', error);
-      });
-  }, []); // The second argument is an empty array, which makes it so that we only run the function once
+    if (props.productId) {
+      // Send axios request to the specific product
+      axios.get('/snuggie/products', { params: { product_id: props.productId } }) // Right now, we have a placeholder for the specific product
+        // Then set the products state
+        .then((results) => {
+          return setProduct(results.data);
+        })
+        // Send axios request to get all styles
+        .then(() => {
+          return axios.get('/snuggie/styles', { params: { product_id: props.productId } });
+        })
+        // Then set the styles state
+        .then((results) => {
+          return setStyles(results.data.results);
+        })
+        // Send axios request to get all the review data that is relevant for the specific product
+        // Then set the reviews state
+        .catch((error) => {
+          console.log('An error occurred when initializing data received from server:', error);
+        });
+    }
+  }, [props.productId]); // The second argument is an empty array, which makes it so that we only run the function once
 
   return (
     <div>


### PR DESCRIPTION
I have refactored the App.js that is the parent of all of the widgets such that it does the following on initial mount:
- send GET request to get a list of all the products in the API
- takes the first product from the returned list and sends a GET request to get that specific product's data
- sets hooks for `productId` (a number representing the product id of that specific product) and `chosenProduct` (an object that has all of that specific product's data)

With this refactoring, you can now pass down the product id (and/or the displayed product itself) as well as the setter hooks to your widget. I've refactored the Overview widget accordingly so it can be used as a reference.

@mrdooby @dondo5252 @justjjasper: Please review for potential conflicts and feel free to refactor/add to App.js's promise chain.