### PR TITLE
feat: implement Star Rating shared component

### DIFF
--- a/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
@@ -4,13 +4,168 @@
 import React, { useState } from 'react';
 import { ProductOverviewStarContainer } from '../StyledComponents/Containers.jsx';
 import ReviewsLink from '../StyledComponents/ProductInformation/OverviewStars.jsx';
+import StarRating from '../../SharedComponents/StarRating.jsx';
 
 // The component
 var OverviewStars = (props) => {
 
   return (
     <ProductOverviewStarContainer>
-      <div>⭐️⭐️⭐️⭐️⭐️</div>
+      <StarRating reviews={{
+    "product": "40344",
+    "page": 0,
+    "count": 10,
+    "results": [
+        {
+            "review_id": 1135846,
+            "rating": 2,
+            "summary": "sdfds",
+            "recommend": true,
+            "response": null,
+            "body": "sdfdsf",
+            "date": "2022-02-22T00:00:00.000Z",
+            "reviewer_name": "sdfsdf",
+            "helpfulness": 47,
+            "photos": []
+        },
+        {
+            "review_id": 1135856,
+            "rating": 1,
+            "summary": "THIS IS A GREEEAAAT REVIEW",
+            "recommend": false,
+            "response": null,
+            "body": "BEST REVIEW EVER WOW OMG WOW THIS REVIEW IS JUST FANTASTIC OH WOW OMG",
+            "date": "2022-02-22T00:00:00.000Z",
+            "reviewer_name": "Daniel",
+            "helpfulness": 12,
+            "photos": []
+        },
+        {
+            "review_id": 1135863,
+            "rating": 1,
+            "summary": "inny is posting a photo for real!!",
+            "recommend": false,
+            "response": null,
+            "body": "LOL",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "inny",
+            "helpfulness": 5,
+            "photos": [
+                {
+                    "id": 2180151,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645581629/hl4mjxfu8xtzxcdk1cr1.jpg"
+                }
+            ]
+        },
+        {
+            "review_id": 1135860,
+            "rating": 4,
+            "summary": "gd",
+            "recommend": false,
+            "response": null,
+            "body": "grere",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "he",
+            "helpfulness": 3,
+            "photos": []
+        },
+        {
+            "review_id": 1135908,
+            "rating": 2,
+            "summary": "f",
+            "recommend": true,
+            "response": null,
+            "body": "f",
+            "date": "2022-02-24T00:00:00.000Z",
+            "reviewer_name": "f",
+            "helpfulness": 1,
+            "photos": []
+        },
+        {
+            "review_id": 1135867,
+            "rating": 1,
+            "summary": "pleasee!!",
+            "recommend": false,
+            "response": null,
+            "body": "work!!!",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "inny",
+            "helpfulness": 1,
+            "photos": [
+                {
+                    "id": 2180154,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645590890/s1vgzd5agk9eju3rimna.png"
+                },
+                {
+                    "id": 2180155,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645590885/tpgtuyvejehvgmiyz4c1.jpg"
+                }
+            ]
+        },
+        {
+            "review_id": 1135864,
+            "rating": 5,
+            "summary": "haha photo!",
+            "recommend": false,
+            "response": null,
+            "body": "PHOTOPHOTO",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "inny",
+            "helpfulness": 1,
+            "photos": [
+                {
+                    "id": 2180152,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645581994/hfn5ygz1chey1fdocdlt.png"
+                }
+            ]
+        },
+        {
+            "review_id": 1135893,
+            "rating": 4,
+            "summary": "yess",
+            "recommend": true,
+            "response": null,
+            "body": "letsgoo",
+            "date": "2022-02-24T00:00:00.000Z",
+            "reviewer_name": "hi",
+            "helpfulness": 0,
+            "photos": [
+                {
+                    "id": 2180173,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645687824/hflmezuz03c7h5pk8b4x.jpg"
+                },
+                {
+                    "id": 2180174,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645687824/cqcftjnunmyheyof0o2u.jpg"
+                }
+            ]
+        },
+        {
+            "review_id": 1135873,
+            "rating": 5,
+            "summary": "This camo onesie is a dream",
+            "recommend": true,
+            "response": null,
+            "body": "camooooooooooooooo",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "monks",
+            "helpfulness": 0,
+            "photos": []
+        },
+        {
+            "review_id": 1135872,
+            "rating": 2,
+            "summary": "yayayayayaya\nayayyaya\nayayaya\nayayya\n",
+            "recommend": true,
+            "response": null,
+            "body": "yayaya\n\nayayay\naya\na",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "ya",
+            "helpfulness": 0,
+            "photos": []
+        }
+    ]
+}} />
       <ReviewsLink>Read [#] Reviews</ReviewsLink>
     </ProductOverviewStarContainer>
   );

--- a/client/src/Components/SharedComponents/StarRating.jsx
+++ b/client/src/Components/SharedComponents/StarRating.jsx
@@ -5,7 +5,19 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 // Styled components
-
+const StarContainer = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: row;
+`;
+const EmptyStar = styled.i`
+  color: gray;
+`;
+const FilledStar = styled.i`
+  color: yellow;
+  width: ${props => props.width};
+  overflow: hidden;
+`;
 
 // The component itself
 const StarRating = (props) => {
@@ -26,7 +38,7 @@ const StarRating = (props) => {
 
 
   return (
-
+    <div></div>
   );
 }
 

--- a/client/src/Components/SharedComponents/StarRating.jsx
+++ b/client/src/Components/SharedComponents/StarRating.jsx
@@ -7,16 +7,21 @@ import styled from 'styled-components';
 // Styled components
 const StarContainer = styled.div`
   position: relative;
-  display: flex;
-  flex-direction: row;
+  display: inline;
+  width: 100%;
 `;
 const EmptyStar = styled.i`
   color: gray;
 `;
 const FilledStar = styled.i`
+  position: absolute;
+  top: 0;
+  left: 0;
   color: yellow;
-  width: ${props => props.width};
   overflow: hidden;
+  width: ${props => props.width}%;
+  height: 100%;
+  z-index: 10;
 `;
 
 // The component itself
@@ -33,12 +38,38 @@ const StarRating = (props) => {
     setAverageRating(rating / props.reviews.count);
   }, [props.reviews]);
 
-
-
-
+  // Construct each star to prepare for render
+  var stars = []; // Array of pairs of stars (pair: an empty one and then a filled one to be rendered on top)
+  let starCount = 0; // Number to keep track of how many stars we've rendered
+  let rating = averageRating; // Copy of the average rating so we don't mutate it
+  while (starCount < 5) { // Keep creating pairs of stars until we have 5 pairs
+    let width = 0;
+    if (rating <= 5 && rating >= 0) { // Determine the width of this star (how much is colored)
+      if (rating < 1) {
+        width = (rating % 1) * 100; // *100 because the styled component turns it into a %
+      } else {
+        width = 100;
+      }
+    }
+    stars.push([<EmptyStar className="fa-solid fa-star" key={`Empty${starCount}`} />, <FilledStar className="fa-solid fa-star" width={width} key={`Fill${starCount}`} />]);
+    rating--; // One pair of stars rendered --> at least a rating of 1
+    starCount++;
+  }
 
   return (
-    <div></div>
+    <StarContainer>
+      {/* For each pair of empty--filled stars... */}
+      {stars.map((starPair, index = 0) => {
+        return (
+          // Render the filled star on top of an empty one
+          <StarContainer key={index++}>
+            {starPair.map((star) => {
+              return star;
+            })}
+          </StarContainer>
+        );
+      })}
+    </StarContainer>
   );
 }
 

--- a/client/src/Components/SharedComponents/StarRating.jsx
+++ b/client/src/Components/SharedComponents/StarRating.jsx
@@ -24,6 +24,13 @@ const FilledStar = styled.i`
   z-index: 10;
 `;
 
+// Helper function to cap the width of a filled star to the nearest increment of 25%
+// Input: A number (intended to be an integer between 0 and 100)
+// Output: A number (multiple of 25)
+var capToFourth = (number) => {
+  return (25 * Math.floor(number / 25));
+}
+
 // The component itself
 const StarRating = (props) => {
 
@@ -46,7 +53,7 @@ const StarRating = (props) => {
     let width = 0;
     if (rating <= 5 && rating >= 0) { // Determine the width of this star (how much is colored)
       if (rating < 1) {
-        width = (rating % 1) * 100; // *100 because the styled component turns it into a %
+        width = capToFourth((rating % 1) * 100); // *100 because the styled component turns it into a %
       } else {
         width = 100;
       }

--- a/client/src/Components/SharedComponents/StarRating.jsx
+++ b/client/src/Components/SharedComponents/StarRating.jsx
@@ -1,0 +1,33 @@
+// The Star Rating component-- the colored stars shown is equivalent to the average rating, accurate up to the fourth of a star
+
+// Import stuff
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+// Styled components
+
+
+// The component itself
+const StarRating = (props) => {
+
+  const [averageRating, setAverageRating] = useState(0);
+
+  // The reviews prop is loaded, calculate the averageRating
+  useEffect(() => {
+    let rating = 0;
+    for (let i = 0; i < props.reviews.count; i++) {
+      rating += props.reviews.results[i].rating;
+    }
+    setAverageRating(rating / props.reviews.count);
+  }, [props.reviews]);
+
+
+
+
+
+  return (
+
+  );
+}
+
+export default StarRating;


### PR DESCRIPTION
- test: in OverviewStarRating.jsx of the Product Overview widget, temporarily pass example reviews as a prop to the Star Rating shared component for shallow testing purposes
- feat: implement Star Rating shared component, located under a SharedComponents folder within the Components directory

My implementation is pretty naive in my opinion and thus there is plenty of room for optimization/improvement. All the component needs as a prop is a list of reviews. It'll iterate through the list of reviews (so O(n) time I think) to grab all the ratings and turn it into an average. Then it takes the average and will render pairs of empty - filled stars (filled ones on top).