### PR TITLE
feat: implement Star Rating shared component and routing to get review metadata

### DIFF
--- a/client/src/Components/ProductOverview/ProductInformation/Information.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/Information.jsx
@@ -35,7 +35,7 @@ var Information = (props) => {
 
   return (
     <ProductInformationContainer>
-      <OverviewStars />
+      <OverviewStars product={props.product} />
       <div>{(props.product && props.product.category) || "Loading Category..."}</div>
       <div>{(props.product && props.product.name) || "Loading Product Name..."}</div>
       {price}

--- a/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
@@ -4,13 +4,168 @@
 import React, { useState } from 'react';
 import { ProductOverviewStarContainer } from '../StyledComponents/Containers.jsx';
 import ReviewsLink from '../StyledComponents/ProductInformation/OverviewStars.jsx';
+import StarRating from '../../SharedComponents/StarRating.jsx';
 
 // The component
 var OverviewStars = (props) => {
 
   return (
     <ProductOverviewStarContainer>
-      <div>⭐️⭐️⭐️⭐️⭐️</div>
+      <StarRating reviews={{
+    "product": "40344",
+    "page": 0,
+    "count": 10,
+    "results": [
+        {
+            "review_id": 1135846,
+            "rating": 2,
+            "summary": "sdfds",
+            "recommend": true,
+            "response": null,
+            "body": "sdfdsf",
+            "date": "2022-02-22T00:00:00.000Z",
+            "reviewer_name": "sdfsdf",
+            "helpfulness": 47,
+            "photos": []
+        },
+        {
+            "review_id": 1135856,
+            "rating": 1,
+            "summary": "THIS IS A GREEEAAAT REVIEW",
+            "recommend": false,
+            "response": null,
+            "body": "BEST REVIEW EVER WOW OMG WOW THIS REVIEW IS JUST FANTASTIC OH WOW OMG",
+            "date": "2022-02-22T00:00:00.000Z",
+            "reviewer_name": "Daniel",
+            "helpfulness": 12,
+            "photos": []
+        },
+        {
+            "review_id": 1135863,
+            "rating": 1,
+            "summary": "inny is posting a photo for real!!",
+            "recommend": false,
+            "response": null,
+            "body": "LOL",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "inny",
+            "helpfulness": 5,
+            "photos": [
+                {
+                    "id": 2180151,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645581629/hl4mjxfu8xtzxcdk1cr1.jpg"
+                }
+            ]
+        },
+        {
+            "review_id": 1135860,
+            "rating": 4,
+            "summary": "gd",
+            "recommend": false,
+            "response": null,
+            "body": "grere",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "he",
+            "helpfulness": 3,
+            "photos": []
+        },
+        {
+            "review_id": 1135908,
+            "rating": 2,
+            "summary": "f",
+            "recommend": true,
+            "response": null,
+            "body": "f",
+            "date": "2022-02-24T00:00:00.000Z",
+            "reviewer_name": "f",
+            "helpfulness": 1,
+            "photos": []
+        },
+        {
+            "review_id": 1135867,
+            "rating": 1,
+            "summary": "pleasee!!",
+            "recommend": false,
+            "response": null,
+            "body": "work!!!",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "inny",
+            "helpfulness": 1,
+            "photos": [
+                {
+                    "id": 2180154,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645590890/s1vgzd5agk9eju3rimna.png"
+                },
+                {
+                    "id": 2180155,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645590885/tpgtuyvejehvgmiyz4c1.jpg"
+                }
+            ]
+        },
+        {
+            "review_id": 1135864,
+            "rating": 5,
+            "summary": "haha photo!",
+            "recommend": false,
+            "response": null,
+            "body": "PHOTOPHOTO",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "inny",
+            "helpfulness": 1,
+            "photos": [
+                {
+                    "id": 2180152,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645581994/hfn5ygz1chey1fdocdlt.png"
+                }
+            ]
+        },
+        {
+            "review_id": 1135893,
+            "rating": 4,
+            "summary": "yess",
+            "recommend": true,
+            "response": null,
+            "body": "letsgoo",
+            "date": "2022-02-24T00:00:00.000Z",
+            "reviewer_name": "hi",
+            "helpfulness": 0,
+            "photos": [
+                {
+                    "id": 2180173,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645687824/hflmezuz03c7h5pk8b4x.jpg"
+                },
+                {
+                    "id": 2180174,
+                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645687824/cqcftjnunmyheyof0o2u.jpg"
+                }
+            ]
+        },
+        {
+            "review_id": 1135873,
+            "rating": 5,
+            "summary": "This camo onesie is a dream",
+            "recommend": true,
+            "response": null,
+            "body": "camooooooooooooooo",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "monks",
+            "helpfulness": 0,
+            "photos": []
+        },
+        {
+            "review_id": 1135872,
+            "rating": 2,
+            "summary": "yayayayayaya\nayayyaya\nayayaya\nayayya\n",
+            "recommend": true,
+            "response": null,
+            "body": "yayaya\n\nayayay\naya\na",
+            "date": "2022-02-23T00:00:00.000Z",
+            "reviewer_name": "ya",
+            "helpfulness": 0,
+            "photos": []
+        }
+    ]
+}} />
       <ReviewsLink>Read [#] Reviews</ReviewsLink>
     </ProductOverviewStarContainer>
   );

--- a/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
@@ -10,7 +10,7 @@ import StarRating from '../../SharedComponents/StarRating.jsx';
 // The component
 var OverviewStars = (props) => {
 
-  const [reviewData, setReviewData] = useState({});
+  const [reviewData, setReviewData] = useState();
 
   // When the prop corresponding to chosenProduct updates, get the review metadata for the product and update this component's hooks
   useEffect(() => {

--- a/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
@@ -11,13 +11,20 @@ import StarRating from '../../SharedComponents/StarRating.jsx';
 var OverviewStars = (props) => {
 
   const [reviewData, setReviewData] = useState();
+  const [reviewCount, setReviewCount] = useState();
 
   // When the prop corresponding to chosenProduct updates, get the review metadata for the product and update this component's hooks
   useEffect(() => {
-    if (props.product) {
+    if (Object.keys(props.product).length !== 0) {
       axios.get('/snuggie/reviews/meta', { params: { product_id: props.product.id }})
         .then((results) => {
-          setReviewData(results.data.ratings);
+          let data = results.data.ratings;
+          setReviewData(data);
+          let count = (data["1"] * 1 + data["2"] * 1 + data["3"] * 1 + data["4"] * 1 + data["5"] * 1);
+          setReviewCount(count);
+        })
+        .catch((error) => {
+          console.log('Error in getting review metadata from server', error);
         })
     }
   }, [props.product])
@@ -25,7 +32,7 @@ var OverviewStars = (props) => {
   return (
     <ProductOverviewStarContainer>
       <StarRating reviewData={reviewData} />
-      <ReviewsLink>Read [#] Reviews</ReviewsLink>
+      <ReviewsLink>{(reviewData && <span>Read {reviewCount} Reviews</span>) || "Loading Reviews..."}</ReviewsLink>
     </ProductOverviewStarContainer>
   );
 }

--- a/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
@@ -1,171 +1,30 @@
 // The component housing the shared Star Rating component and the link to 'Read [#] Reviews'
 
 // Import stuff
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ProductOverviewStarContainer } from '../StyledComponents/Containers.jsx';
+import axios from 'axios';
 import ReviewsLink from '../StyledComponents/ProductInformation/OverviewStars.jsx';
 import StarRating from '../../SharedComponents/StarRating.jsx';
 
 // The component
 var OverviewStars = (props) => {
 
+  const [reviewData, setReviewData] = useState({});
+
+  // When the prop corresponding to chosenProduct updates, get the review metadata for the product and update this component's hooks
+  useEffect(() => {
+    if (props.product) {
+      axios.get('/reviews/meta', { params: { product_id: props.product.productId }})
+        .then((results) => {
+          setReviewData(results.data.ratings);
+        })
+    }
+  }, [props.product])
+
   return (
     <ProductOverviewStarContainer>
-      <StarRating reviews={{
-    "product": "40344",
-    "page": 0,
-    "count": 10,
-    "results": [
-        {
-            "review_id": 1135846,
-            "rating": 2,
-            "summary": "sdfds",
-            "recommend": true,
-            "response": null,
-            "body": "sdfdsf",
-            "date": "2022-02-22T00:00:00.000Z",
-            "reviewer_name": "sdfsdf",
-            "helpfulness": 47,
-            "photos": []
-        },
-        {
-            "review_id": 1135856,
-            "rating": 1,
-            "summary": "THIS IS A GREEEAAAT REVIEW",
-            "recommend": false,
-            "response": null,
-            "body": "BEST REVIEW EVER WOW OMG WOW THIS REVIEW IS JUST FANTASTIC OH WOW OMG",
-            "date": "2022-02-22T00:00:00.000Z",
-            "reviewer_name": "Daniel",
-            "helpfulness": 12,
-            "photos": []
-        },
-        {
-            "review_id": 1135863,
-            "rating": 1,
-            "summary": "inny is posting a photo for real!!",
-            "recommend": false,
-            "response": null,
-            "body": "LOL",
-            "date": "2022-02-23T00:00:00.000Z",
-            "reviewer_name": "inny",
-            "helpfulness": 5,
-            "photos": [
-                {
-                    "id": 2180151,
-                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645581629/hl4mjxfu8xtzxcdk1cr1.jpg"
-                }
-            ]
-        },
-        {
-            "review_id": 1135860,
-            "rating": 4,
-            "summary": "gd",
-            "recommend": false,
-            "response": null,
-            "body": "grere",
-            "date": "2022-02-23T00:00:00.000Z",
-            "reviewer_name": "he",
-            "helpfulness": 3,
-            "photos": []
-        },
-        {
-            "review_id": 1135908,
-            "rating": 2,
-            "summary": "f",
-            "recommend": true,
-            "response": null,
-            "body": "f",
-            "date": "2022-02-24T00:00:00.000Z",
-            "reviewer_name": "f",
-            "helpfulness": 1,
-            "photos": []
-        },
-        {
-            "review_id": 1135867,
-            "rating": 1,
-            "summary": "pleasee!!",
-            "recommend": false,
-            "response": null,
-            "body": "work!!!",
-            "date": "2022-02-23T00:00:00.000Z",
-            "reviewer_name": "inny",
-            "helpfulness": 1,
-            "photos": [
-                {
-                    "id": 2180154,
-                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645590890/s1vgzd5agk9eju3rimna.png"
-                },
-                {
-                    "id": 2180155,
-                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645590885/tpgtuyvejehvgmiyz4c1.jpg"
-                }
-            ]
-        },
-        {
-            "review_id": 1135864,
-            "rating": 5,
-            "summary": "haha photo!",
-            "recommend": false,
-            "response": null,
-            "body": "PHOTOPHOTO",
-            "date": "2022-02-23T00:00:00.000Z",
-            "reviewer_name": "inny",
-            "helpfulness": 1,
-            "photos": [
-                {
-                    "id": 2180152,
-                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645581994/hfn5ygz1chey1fdocdlt.png"
-                }
-            ]
-        },
-        {
-            "review_id": 1135893,
-            "rating": 4,
-            "summary": "yess",
-            "recommend": true,
-            "response": null,
-            "body": "letsgoo",
-            "date": "2022-02-24T00:00:00.000Z",
-            "reviewer_name": "hi",
-            "helpfulness": 0,
-            "photos": [
-                {
-                    "id": 2180173,
-                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645687824/hflmezuz03c7h5pk8b4x.jpg"
-                },
-                {
-                    "id": 2180174,
-                    "url": "http://res.cloudinary.com/dhx5k7wb3/image/upload/v1645687824/cqcftjnunmyheyof0o2u.jpg"
-                }
-            ]
-        },
-        {
-            "review_id": 1135873,
-            "rating": 5,
-            "summary": "This camo onesie is a dream",
-            "recommend": true,
-            "response": null,
-            "body": "camooooooooooooooo",
-            "date": "2022-02-23T00:00:00.000Z",
-            "reviewer_name": "monks",
-            "helpfulness": 0,
-            "photos": []
-        },
-        {
-            "review_id": 1135872,
-            "rating": 2,
-            "summary": "yayayayayaya\nayayyaya\nayayaya\nayayya\n",
-            "recommend": true,
-            "response": null,
-            "body": "yayaya\n\nayayay\naya\na",
-            "date": "2022-02-23T00:00:00.000Z",
-            "reviewer_name": "ya",
-            "helpfulness": 0,
-            "photos": []
-        }
-    ]
-}} />
+      <StarRating reviewData={reviewData} />
       <ReviewsLink>Read [#] Reviews</ReviewsLink>
     </ProductOverviewStarContainer>
   );

--- a/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/OverviewStarRating.jsx
@@ -15,7 +15,7 @@ var OverviewStars = (props) => {
   // When the prop corresponding to chosenProduct updates, get the review metadata for the product and update this component's hooks
   useEffect(() => {
     if (props.product) {
-      axios.get('/reviews/meta', { params: { product_id: props.product.productId }})
+      axios.get('/snuggie/reviews/meta', { params: { product_id: props.product.id }})
         .then((results) => {
           setReviewData(results.data.ratings);
         })

--- a/client/src/Components/SharedComponents/StarRating.jsx
+++ b/client/src/Components/SharedComponents/StarRating.jsx
@@ -5,7 +5,19 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 // Styled components
-
+const StarContainer = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: row;
+`;
+const EmptyStar = styled.i`
+  color: gray;
+`;
+const FilledStar = styled.i`
+  color: yellow;
+  width: ${props => props.width};
+  overflow: hidden;
+`;
 
 // The component itself
 const StarRating = (props) => {
@@ -26,7 +38,7 @@ const StarRating = (props) => {
 
 
   return (
-
+    <div></div>
   );
 }
 

--- a/client/src/Components/SharedComponents/StarRating.jsx
+++ b/client/src/Components/SharedComponents/StarRating.jsx
@@ -39,11 +39,19 @@ const StarRating = (props) => {
   // The reviews prop is loaded, calculate the averageRating
   useEffect(() => {
     let rating = 0;
-    for (let i = 0; i < props.reviews.count; i++) {
-      rating += props.reviews.results[i].rating;
+    let data = props.reviewData;
+    console.log(data);
+
+    // for (let i = 0; i < props.reviews.count; i++) {
+    //   rating += props.reviews.results[i].rating;
+    // }
+    // setAverageRating(rating / props.reviews.count);
+
+    if (data) {
+      rating = (data.ratings["1"] * 1) + (data.ratings["2"] * 2) + (data.ratings["3"] * 3) + (data.ratings["4"] * 4) + (data.ratings["5"] * 5)
+      setAverageRating(rating / (data.ratings["1"] + data.ratings["2"] + data.ratings["3"] + data.ratings["4"] + data.ratings["5"]))
     }
-    setAverageRating(rating / props.reviews.count);
-  }, [props.reviews]);
+  }, [props.reviewData]);
 
   // Construct each star to prepare for render
   var stars = []; // Array of pairs of stars (pair: an empty one and then a filled one to be rendered on top)

--- a/client/src/Components/SharedComponents/StarRating.jsx
+++ b/client/src/Components/SharedComponents/StarRating.jsx
@@ -7,16 +7,21 @@ import styled from 'styled-components';
 // Styled components
 const StarContainer = styled.div`
   position: relative;
-  display: flex;
-  flex-direction: row;
+  display: inline;
+  width: 100%;
 `;
 const EmptyStar = styled.i`
   color: gray;
 `;
 const FilledStar = styled.i`
+  position: absolute;
+  top: 0;
+  left: 0;
   color: yellow;
-  width: ${props => props.width};
   overflow: hidden;
+  width: ${props => props.width}%;
+  height: 100%;
+  z-index: 10;
 `;
 
 // The component itself
@@ -33,12 +38,38 @@ const StarRating = (props) => {
     setAverageRating(rating / props.reviews.count);
   }, [props.reviews]);
 
-
-
-
+  // Construct each star to prepare for render
+  var stars = []; // Array of pairs of stars (pair: an empty one and then a filled one to be rendered on top)
+  let starCount = 0; // Number to keep track of how many stars we've rendered
+  let rating = averageRating; // Copy of the average rating so we don't mutate it
+  while (starCount < 5) { // Keep creating pairs of stars until we have 5 pairs
+    let width = 0;
+    if (rating <= 5 && rating >= 0) { // Determine the width of this star (how much is colored)
+      if (rating < 1) {
+        width = (rating % 1) * 100; // *100 because the styled component turns it into a %
+      } else {
+        width = 100;
+      }
+    }
+    stars.push([<EmptyStar className="fa-solid fa-star" key={`Empty${starCount}`} />, <FilledStar className="fa-solid fa-star" width={width} key={`Fill${starCount}`} />]);
+    rating--; // One pair of stars rendered --> at least a rating of 1
+    starCount++;
+  }
 
   return (
-    <div></div>
+    <StarContainer>
+      {/* For each pair of empty--filled stars... */}
+      {stars.map((starPair, index = 0) => {
+        return (
+          // Render the filled star on top of an empty one
+          <StarContainer key={index++}>
+            {starPair.map((star) => {
+              return star;
+            })}
+          </StarContainer>
+        );
+      })}
+    </StarContainer>
   );
 }
 

--- a/client/src/Components/SharedComponents/StarRating.jsx
+++ b/client/src/Components/SharedComponents/StarRating.jsx
@@ -24,6 +24,13 @@ const FilledStar = styled.i`
   z-index: 10;
 `;
 
+// Helper function to cap the width of a filled star to the nearest increment of 25%
+// Input: A number (intended to be an integer between 0 and 100)
+// Output: A number (multiple of 25)
+var capToFourth = (number) => {
+  return (25 * Math.floor(number / 25));
+}
+
 // The component itself
 const StarRating = (props) => {
 
@@ -46,7 +53,7 @@ const StarRating = (props) => {
     let width = 0;
     if (rating <= 5 && rating >= 0) { // Determine the width of this star (how much is colored)
       if (rating < 1) {
-        width = (rating % 1) * 100; // *100 because the styled component turns it into a %
+        width = capToFourth((rating % 1) * 100); // *100 because the styled component turns it into a %
       } else {
         width = 100;
       }

--- a/client/src/Components/SharedComponents/StarRating.jsx
+++ b/client/src/Components/SharedComponents/StarRating.jsx
@@ -40,16 +40,10 @@ const StarRating = (props) => {
   useEffect(() => {
     let rating = 0;
     let data = props.reviewData;
-    console.log(data);
-
-    // for (let i = 0; i < props.reviews.count; i++) {
-    //   rating += props.reviews.results[i].rating;
-    // }
-    // setAverageRating(rating / props.reviews.count);
-
     if (data) {
-      rating = (data.ratings["1"] * 1) + (data.ratings["2"] * 2) + (data.ratings["3"] * 3) + (data.ratings["4"] * 4) + (data.ratings["5"] * 5)
-      setAverageRating(rating / (data.ratings["1"] + data.ratings["2"] + data.ratings["3"] + data.ratings["4"] + data.ratings["5"]))
+      rating = (data["1"] * 1) + (data["2"] * 2) + (data["3"] * 3) + (data["4"] * 4) + (data["5"] * 5);
+      // Multiply each data[rating] by 1 turns it into a number (it is originally type string)
+      setAverageRating(rating / (data["1"] * 1 + data["2"] * 1 + data["3"] * 1 + data["4"] * 1 + data["5"] * 1));
     }
   }, [props.reviewData]);
 

--- a/client/src/Components/SharedComponents/StarRating.jsx
+++ b/client/src/Components/SharedComponents/StarRating.jsx
@@ -1,0 +1,33 @@
+// The Star Rating component-- the colored stars shown is equivalent to the average rating, accurate up to the fourth of a star
+
+// Import stuff
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+// Styled components
+
+
+// The component itself
+const StarRating = (props) => {
+
+  const [averageRating, setAverageRating] = useState(0);
+
+  // The reviews prop is loaded, calculate the averageRating
+  useEffect(() => {
+    let rating = 0;
+    for (let i = 0; i < props.reviews.count; i++) {
+      rating += props.reviews.results[i].rating;
+    }
+    setAverageRating(rating / props.reviews.count);
+  }, [props.reviews]);
+
+
+
+
+
+  return (
+
+  );
+}
+
+export default StarRating;

--- a/server/helpers/HR_API.jsx
+++ b/server/helpers/HR_API.jsx
@@ -38,6 +38,13 @@ var getProductReviews = (id, count, sort) => {
   });
 }
 
+// Function that sends a GET request to the API to get a specific product's review metadata
+var getReviewMetadata = (id) => {
+  return axios.get(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/reviews/meta?product_id=${id}`, {
+    headers: headers
+  });
+}
+
 var postProductReviews = (data) => {
   return axios.post(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/reviews`, data, {
     headers: headers
@@ -95,6 +102,7 @@ module.exports.getAllProducts = getAllProducts;
 module.exports.getProduct = getProduct;
 module.exports.getProductStyles = getProductStyles;
 module.exports.getProductReviews = getProductReviews;
+module.exports.getReviewMetadata = getReviewMetadata;
 module.exports.postProductReviews = postProductReviews;
 module.exports.getRelatedProducts = getRelatedProducts;
 module.exports.getProductQuestion = getProductQuestion;

--- a/server/routes.js
+++ b/server/routes.js
@@ -19,7 +19,7 @@ router.get('/products', (request, response) => {
     })
     .catch((error) => {
       console.log('Error in getting all the products', error);
-      response.send(500);
+      response.sendStatus(500);
     });
 });
 
@@ -28,7 +28,7 @@ router.get('/products', (request, response) => {
 router.get('/styles', (request, response) => {
   // If there is no product_id as the parameter, return bad response
   if (!request.query.product_id) {
-    response.send(500);
+    response.sendStatus(500);
   } else {
     API.getProductStyles(request.query.product_id)
       .then((results) => {
@@ -53,6 +53,22 @@ router.get('/reviews/', (request, response) => {
       .catch((error) => {
         console.log('Error in getting all the reviews', error);
         response.send(500);
+      });
+  }
+});
+
+// GETs a specific product's review metadata
+router.get('/reviews/meta', (request, response) => {
+  if (!request.query.product_id) {
+    response.sendStatus(500);
+  } else {
+    API.getReviewMetadata(request.query.product_id)
+      .then((results) => {
+        response.status(200).send(results.data);
+      })
+      .catch((error) => {
+        console.log('Error in getting the review metadata', error);
+        results.sendStatus(500);
       });
   }
 });


### PR DESCRIPTION
Includes content from previous, cancelled pull request [here](https://github.com/TeamSnuggie/FEC/pull/41).

- feat: implement Star Rating shared component, located under a SharedComponents folder within the Components directory

My implementation is pretty naive in my opinion and thus there is plenty of room for optimization/improvement. All the component needs as a prop is an object that is the review metadata. It'll get the review metadata received from the API and turn it into an average. Then it takes the average and will render pairs of empty - filled stars (filled ones on top).

- feat: add client-side (on Overview widget) and server-side routing and API helper function to get review metadata from API

Add /snuggies/reviews/meta endpoint to server

- feat: dynamically render "Read [#] Reviews" with number of reviews (calculated from in metadata)