### PR TITLE
build: configure package.json script and jest config to show coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,12 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.{js,jsx}'],
+  collectCoverageFrom: ['./client/src/**/*.js',
+                        './client/src/**/*.jsx',
+                        "**/*.{js,jsx}",
+                        "!**/node_modules/**",
+                        "!**/*.config.js",
+                        "!**/bundle.js",
+                        "!**/coverage/**"],
   coverageDirectory: 'coverage',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "server-start": "nodemon server.js -w",
     "client-start": "webpack --config webpack.config.js -w",
-    "test": "jest --env=jsdom",
-    "coverage": "jest --coverage"
+    "test": "jest",
+    "test:coverage": "jest --config ./jest.config.js --coverage"
   },
   "keywords": [],
   "author": "Aaron Pan <adpan.dev@gmail.com>",


### PR DESCRIPTION
Implement following refactoring of package.json and jest.config.js to allow for coverage:

- collectCoverageFrom adjusted such that it actually collects coverage from the correct files (it wasn't before)
- clean up package.json test scripts