### PR TITLE
feat: implement expanded view and zoom mode on Main Image

### DIFF
--- a/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
@@ -42,7 +42,7 @@ var Gallery = (props) => {
 
     <ImageGalleryContainer>
       <RelativeWrapper>
-        <ThumbnailList imageThumbnails={imageThumbnails} chosenImageUrl={chosenImageUrl} setChosenImageUrl={setChosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} />
+        <ThumbnailList imageThumbnails={imageThumbnails} chosenImageUrl={chosenImageUrl} setChosenImageUrl={setChosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} expanded={expanded} zoomed={zoomed} />
         <MainImage chosenImageUrl={chosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} maxIndex={maxIndex} expanded={expanded} setExpanded={setExpanded} zoomed={zoomed} setZoomed={setZoomed} />
       </RelativeWrapper>
     </ImageGalleryContainer>

--- a/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
@@ -21,12 +21,14 @@ var Gallery = (props) => {
   useEffect(() => {
     if (props.chosenStyle.photos) {
       setImageThumbnails(props.chosenStyle.photos);
-      setChosenImageUrl(props.chosenStyle.photos[chosenImageIndex].url);
-      if (chosenImageIndex) {
+      if (chosenImageIndex <= props.chosenStyle.photos.length - 1) {
         setChosenImageIndex(chosenImageIndex);
+        setChosenImageUrl(props.chosenStyle.photos[chosenImageIndex].url);
       } else {
         setChosenImageIndex(0);
+        setChosenImageUrl(props.chosenStyle.photos[0].url);
       }
+      console.log('AJJJJ', chosenImageIndex, props.chosenStyle);
       setMaxIndex(props.chosenStyle.photos.length - 1);
     }
   }, [props.chosenStyle])

--- a/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
@@ -3,6 +3,7 @@
 // Import stuff
 import React, { useState, useEffect } from 'react';
 import { ImageGalleryContainer } from '../StyledComponents/Containers.jsx';
+import { RelativeWrapper } from '../StyledComponents/ImageGallery/MainImage.jsx';
 import MainImage from './MainImage.jsx';
 import ThumbnailList from './ThumbnailList.jsx';
 
@@ -38,8 +39,10 @@ var Gallery = (props) => {
   return (
 
     <ImageGalleryContainer>
-      <ThumbnailList imageThumbnails={imageThumbnails} chosenImageUrl={chosenImageUrl} setChosenImageUrl={setChosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} />
-      <MainImage chosenImageUrl={chosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} maxIndex={maxIndex} />
+      <RelativeWrapper>
+        <ThumbnailList imageThumbnails={imageThumbnails} chosenImageUrl={chosenImageUrl} setChosenImageUrl={setChosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} />
+        <MainImage chosenImageUrl={chosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} maxIndex={maxIndex} />
+      </RelativeWrapper>
     </ImageGalleryContainer>
 
   );

--- a/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
@@ -14,6 +14,7 @@ var Gallery = (props) => {
   const [chosenImageUrl, setChosenImageUrl] = useState('');
   const [chosenImageIndex, setChosenImageIndex] = useState(0);
   const [maxIndex, setMaxIndex] = useState(0);
+  const [expanded, setExpanded] = useState(false);
 
   // When the chosenStyle state is updated, update this component's hooks accordingly
   useEffect(() => {
@@ -41,7 +42,7 @@ var Gallery = (props) => {
     <ImageGalleryContainer>
       <RelativeWrapper>
         <ThumbnailList imageThumbnails={imageThumbnails} chosenImageUrl={chosenImageUrl} setChosenImageUrl={setChosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} />
-        <MainImage chosenImageUrl={chosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} maxIndex={maxIndex} />
+        <MainImage chosenImageUrl={chosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} maxIndex={maxIndex} expanded={expanded} setExpanded={setExpanded} />
       </RelativeWrapper>
     </ImageGalleryContainer>
 

--- a/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
@@ -19,7 +19,11 @@ var Gallery = (props) => {
     if (props.chosenStyle.photos) {
       setImageThumbnails(props.chosenStyle.photos);
       setChosenImageUrl(props.chosenStyle.photos[chosenImageIndex].url);
-      setChosenImageIndex(0);
+      if (chosenImageIndex) {
+        setChosenImageIndex(chosenImageIndex);
+      } else {
+        setChosenImageIndex(0);
+      }
       setMaxIndex(props.chosenStyle.photos.length - 1);
     }
   }, [props.chosenStyle])

--- a/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/Gallery.jsx
@@ -15,6 +15,7 @@ var Gallery = (props) => {
   const [chosenImageIndex, setChosenImageIndex] = useState(0);
   const [maxIndex, setMaxIndex] = useState(0);
   const [expanded, setExpanded] = useState(false);
+  const [zoomed, setZoomed] = useState(false);
 
   // When the chosenStyle state is updated, update this component's hooks accordingly
   useEffect(() => {
@@ -42,7 +43,7 @@ var Gallery = (props) => {
     <ImageGalleryContainer>
       <RelativeWrapper>
         <ThumbnailList imageThumbnails={imageThumbnails} chosenImageUrl={chosenImageUrl} setChosenImageUrl={setChosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} />
-        <MainImage chosenImageUrl={chosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} maxIndex={maxIndex} expanded={expanded} setExpanded={setExpanded} />
+        <MainImage chosenImageUrl={chosenImageUrl} chosenImageIndex={chosenImageIndex} setChosenImageIndex={setChosenImageIndex} maxIndex={maxIndex} expanded={expanded} setExpanded={setExpanded} zoomed={zoomed} setZoomed={setZoomed} />
       </RelativeWrapper>
     </ImageGalleryContainer>
 

--- a/client/src/Components/ProductOverview/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ImageZoom.jsx
@@ -1,0 +1,45 @@
+import React, { useState, useEffect } from 'react';
+import { ImageZoomContainer, Magnifier, ZoomedImage } from '../StyledComponents/ImageGallery/ImageZoom.jsx';
+
+const ImageZoom = (props) => {
+
+  /* Component needs
+  img src: props.imageUrl
+  zoom: 2.5x
+  */
+
+  const [magnifier, setMagnifier] = useState(2.5); // magnitude of zoom
+  const [magnifying, setMagnifying] = useState(false); // whether or not the magnifier is applied
+  const [[x, y], setMousePosition] = useState([0, 0]); // for keeping track of the mouse's position when hovering over the image to zoom
+
+  // Function to calculate the position of the magnifier div
+  // const handleMouseEnter = (event) => {
+  //   const imageElement = event.currentTarget;
+  //   const { width, height } = imageElement.getBoundingClientRect();
+  //   setMagnifying(true);
+  // }
+
+  // Function to handle updating position of mouse cursor when mouse moves over image to zoom
+  const handleMouseMove = (event) => {
+    const imageElement = event.currentTarget;
+    const { top, left } = imageElement.getBoundingClientRect();
+    // Calculate the mouse cursor position on the image to zoom
+    // Coordinates on page - coordinates of image top/left position - scroll offsets of page
+    const x = event.pageX - left - window.pageXOffset;
+    const y = event.pageY - top - window.pageYOffset;
+    setMousePosition([x, y]);
+  }
+
+  return (
+    <ImageZoomContainer>
+      <ZoomedImage src={props.imageUrl}
+        onMouseEnter={(event) => { setMagnifying(true); }}
+        onMouseLeave={() => { setMagnifying(false); }}
+        onMouseMove={(event) => { handleMouseMove(event) }}
+      />
+      {magnifying && <Magnifier imageUrl={props.imageUrl} magnifier={magnifier} x={x} y={y} />}
+    </ImageZoomContainer>
+  );
+}
+
+export default ImageZoom;

--- a/client/src/Components/ProductOverview/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ImageZoom.jsx
@@ -10,14 +10,16 @@ const ImageZoom = (props) => {
 
   const [magnifier, setMagnifier] = useState(2.5); // magnitude of zoom
   const [magnifying, setMagnifying] = useState(false); // whether or not the magnifier is applied
+  const [[imageWidth, imageHeight], setSize] = useState([0, 0]);
   const [[x, y], setMousePosition] = useState([0, 0]); // for keeping track of the mouse's position when hovering over the image to zoom
 
   // Function to calculate the position of the magnifier div
-  // const handleMouseEnter = (event) => {
-  //   const imageElement = event.currentTarget;
-  //   const { width, height } = imageElement.getBoundingClientRect();
-  //   setMagnifying(true);
-  // }
+  const handleMouseEnter = (event) => {
+    const imageElement = event.currentTarget;
+    const { width, height } = imageElement.getBoundingClientRect();
+    setSize([width, height]);
+    setMagnifying(true);
+  }
 
   // Function to handle updating position of mouse cursor when mouse moves over image to zoom
   const handleMouseMove = (event) => {
@@ -33,12 +35,12 @@ const ImageZoom = (props) => {
   return (
     <ImageZoomContainer>
       <ZoomedImage src={props.imageUrl}
-        onMouseEnter={(event) => { setMagnifying(true); }}
+        onMouseEnter={(event) => { handleMouseEnter(event); }}
         onMouseLeave={() => { setMagnifying(false); }}
         onMouseMove={(event) => { handleMouseMove(event) }}
         onClick={() => { props.setZoomed(false); }}
       />
-      {magnifying && <Magnifier imageUrl={props.imageUrl} magnifier={magnifier} x={x} y={y} />}
+      {magnifying && <Magnifier imageUrl={props.imageUrl} magnifier={magnifier} x={x} y={y} imageWidth={imageWidth} imageHeight={imageHeight} />}
     </ImageZoomContainer>
   );
 }

--- a/client/src/Components/ProductOverview/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ImageZoom.jsx
@@ -36,6 +36,7 @@ const ImageZoom = (props) => {
         onMouseEnter={(event) => { setMagnifying(true); }}
         onMouseLeave={() => { setMagnifying(false); }}
         onMouseMove={(event) => { handleMouseMove(event) }}
+        onClick={() => { props.setZoomed(false); }}
       />
       {magnifying && <Magnifier imageUrl={props.imageUrl} magnifier={magnifier} x={x} y={y} />}
     </ImageZoomContainer>

--- a/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
@@ -16,16 +16,21 @@ var MainImage = (props) => {
         <ExpandedOverlay>
           {props.chosenImageIndex > 0 && <LeftArrow className="fa-solid fa-arrow-left" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex - 1)}} />}
             {props.chosenImageIndex < props.maxIndex && <RightArrow className="fa-solid fa-arrow-right" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex + 1)}} />}
-          <FullScreen className="fa-solid fa-expand" onClick={() => {console.log('Contract'); props.setExpanded(false);}} />
+          <FullScreen className="fa-solid fa-expand"
+            onClick={() => {
+              console.log('Contract');
+              props.setExpanded(false);
+              props.setZoomed(false); // This may be unnecessary
+            }}
+          />
         </ExpandedOverlay>
-        <Image src={props.chosenImageUrl} />
+        <Image src={props.chosenImageUrl} onClick={() => { console.log('Zoom!'); props.setZoomed(!props.zoomed);}} />
       </ExpandedView>
     );
   // Else render the default view
   } else {
     return (
       <div>
-
         <DefaultView>
           <DefaultOverlay>
             {props.chosenImageIndex > 0 && <LeftArrow className="fa-solid fa-arrow-left" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex - 1)}} />}

--- a/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
@@ -3,14 +3,20 @@
 // Import stuff
 import React, { useState } from 'react';
 import { Image, DefaultView, DefaultOverlay, LeftArrow, RightArrow, FullScreen, ExpandedView, ExpandedOverlay } from '../StyledComponents/ImageGallery/MainImage.jsx';
+import ImageZoom from './ImageZoom.jsx';
 
 // The component
 var MainImage = (props) => {
 
   // const [expanded, setExpanded] = useState(false);
 
+  // If the view is zoomed view, render the zoomed view
+  if (props.zoomed) {
+    return (
+      <ImageZoom imageUrl={props.chosenImageUrl} />
+    );
   // If the view is expanded view, render the expanded view
-  if (props.expanded) {
+  } else if (props.expanded) {
     return (
       <ExpandedView>
         <ExpandedOverlay>

--- a/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
@@ -2,17 +2,22 @@
 
 // Import stuff
 import React, { useState } from 'react';
-import { Image, DefaultView, DefaultOverlay, LeftArrow, RightArrow, FullScreen, ExpandedView } from '../StyledComponents/ImageGallery/MainImage.jsx';
+import { Image, DefaultView, DefaultOverlay, LeftArrow, RightArrow, FullScreen, ExpandedView, ExpandedOverlay } from '../StyledComponents/ImageGallery/MainImage.jsx';
 
 // The component
 var MainImage = (props) => {
 
-  const [view, setView] = useState('default');
+  const [expanded, setExpanded] = useState(false);
 
   // If the view is expanded view, render the expanded view
-  if (view === 'expanded') {
+  if (expanded) {
     return (
       <ExpandedView>
+        <ExpandedOverlay>
+          {props.chosenImageIndex > 0 && <LeftArrow className="fa-solid fa-arrow-left" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex - 1)}} />}
+            {props.chosenImageIndex < props.maxIndex && <RightArrow className="fa-solid fa-arrow-right" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex + 1)}} />}
+          <FullScreen className="fa-solid fa-expand" onClick={() => {console.log('Contract'); setExpanded(false);}} />
+        </ExpandedOverlay>
         <Image src={props.chosenImageUrl} />
       </ExpandedView>
     );
@@ -25,9 +30,9 @@ var MainImage = (props) => {
           <DefaultOverlay>
             {props.chosenImageIndex > 0 && <LeftArrow className="fa-solid fa-arrow-left" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex - 1)}} />}
             {props.chosenImageIndex < props.maxIndex && <RightArrow className="fa-solid fa-arrow-right" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex + 1)}} />}
-            <FullScreen className="fa-solid fa-expand" />
+            <FullScreen className="fa-solid fa-expand" onClick={() => {console.log('Expand!'); setExpanded(true);}} />
           </DefaultOverlay>
-          <Image id="MainImage" src={props.chosenImageUrl} />
+          <Image id="MainImage" src={props.chosenImageUrl} onClick={() => {console.log('Expand!'); setExpanded(true);}} />
         </DefaultView>
       </div>
     );

--- a/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
@@ -7,16 +7,16 @@ import { Image, DefaultView, DefaultOverlay, LeftArrow, RightArrow, FullScreen, 
 // The component
 var MainImage = (props) => {
 
-  const [expanded, setExpanded] = useState(false);
+  // const [expanded, setExpanded] = useState(false);
 
   // If the view is expanded view, render the expanded view
-  if (expanded) {
+  if (props.expanded) {
     return (
       <ExpandedView>
         <ExpandedOverlay>
           {props.chosenImageIndex > 0 && <LeftArrow className="fa-solid fa-arrow-left" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex - 1)}} />}
             {props.chosenImageIndex < props.maxIndex && <RightArrow className="fa-solid fa-arrow-right" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex + 1)}} />}
-          <FullScreen className="fa-solid fa-expand" onClick={() => {console.log('Contract'); setExpanded(false);}} />
+          <FullScreen className="fa-solid fa-expand" onClick={() => {console.log('Contract'); props.setExpanded(false);}} />
         </ExpandedOverlay>
         <Image src={props.chosenImageUrl} />
       </ExpandedView>
@@ -30,9 +30,9 @@ var MainImage = (props) => {
           <DefaultOverlay>
             {props.chosenImageIndex > 0 && <LeftArrow className="fa-solid fa-arrow-left" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex - 1)}} />}
             {props.chosenImageIndex < props.maxIndex && <RightArrow className="fa-solid fa-arrow-right" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex + 1)}} />}
-            <FullScreen className="fa-solid fa-expand" onClick={() => {console.log('Expand!'); setExpanded(true);}} />
+            <FullScreen className="fa-solid fa-expand" onClick={() => {console.log('Expand!'); props.setExpanded(true);}} />
           </DefaultOverlay>
-          <Image id="MainImage" src={props.chosenImageUrl} onClick={() => {console.log('Expand!'); setExpanded(true);}} />
+          <Image id="MainImage" src={props.chosenImageUrl} onClick={() => {console.log('Expand!'); props.setExpanded(true);}} />
         </DefaultView>
       </div>
     );

--- a/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
@@ -13,7 +13,7 @@ var MainImage = (props) => {
   // If the view is zoomed view, render the zoomed view
   if (props.zoomed) {
     return (
-      <ImageZoom imageUrl={props.chosenImageUrl} />
+      <ImageZoom imageUrl={props.chosenImageUrl} setZoomed={props.setZoomed} />
     );
   // If the view is expanded view, render the expanded view
   } else if (props.expanded) {

--- a/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/MainImage.jsx
@@ -2,7 +2,7 @@
 
 // Import stuff
 import React, { useState } from 'react';
-import { Image, DefaultView, Overlay, LeftArrow, RightArrow, FullScreen, ExpandedView } from '../StyledComponents/ImageGallery/MainImage.jsx';
+import { Image, DefaultView, DefaultOverlay, LeftArrow, RightArrow, FullScreen, ExpandedView } from '../StyledComponents/ImageGallery/MainImage.jsx';
 
 // The component
 var MainImage = (props) => {
@@ -22,11 +22,11 @@ var MainImage = (props) => {
       <div>
 
         <DefaultView>
-          <Overlay>
+          <DefaultOverlay>
             {props.chosenImageIndex > 0 && <LeftArrow className="fa-solid fa-arrow-left" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex - 1)}} />}
             {props.chosenImageIndex < props.maxIndex && <RightArrow className="fa-solid fa-arrow-right" onClick={() => {props.setChosenImageIndex(props.chosenImageIndex + 1)}} />}
             <FullScreen className="fa-solid fa-expand" />
-          </Overlay>
+          </DefaultOverlay>
           <Image id="MainImage" src={props.chosenImageUrl} />
         </DefaultView>
       </div>

--- a/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
@@ -2,7 +2,7 @@
 
 // Import stuff
 import React, { useState, useEffect } from 'react';
-import { ImageThumbnails, Div, ChosenDiv, Arrow } from '../StyledComponents/ImageGallery/ImageThumbnails.jsx';
+import { ImageThumbnails, Div, ChosenDiv, Arrow, ImageThumbnailIconContainer, ImageThumbnailIcon } from '../StyledComponents/ImageGallery/ImageThumbnails.jsx';
 import Thumbnail from './Thumbnail.jsx';
 
 // The list component itself
@@ -18,23 +18,36 @@ var ThumbnailList = (props) => {
     setShown(props.imageThumbnails.slice(index, index + 7));
   }, [index, props.imageThumbnails])
 
+  // If the zoomed state is not active...
+  if (!props.zoomed) {
+    // ...and the view is expanded, render the default Image Thumbnail List
+    if (props.expanded) {
+      return (
+        <ImageThumbnailIconContainer>
+          <ImageThumbnailIcon className="fa-solid fa-circle" />
+        </ImageThumbnailIconContainer>
+      );
+    // Else the view is not expanded so render the default Image Thumbnail List
+    } else {
+      return (
+        <ImageThumbnails>
+          {index > 0 && <Arrow className="fa-solid fa-arrow-up" key={"LeftArrow"} onClick={() => {setIndex(index - 1)}} /> /* If the starting index is > 0, render an up arrow */}
+          {shown.map((thumbnail, keyIndex = 0) => {
+            // If the thumbnail is the chosen one, also render a box around it to indicate that it's the chosen one
+            if (keyIndex + index === props.chosenImageIndex) {
+              return (
+                <ChosenDiv key={"ChosenDiv"}><Thumbnail className="chosenImage" thumbnail={thumbnail} index={index + keyIndex} key={keyIndex++} setChosenImageIndex={props.setChosenImageIndex} /></ChosenDiv>
+              );
+            }
+            // Else just render the thumbnail itself
+            return (<Div key={`Div${keyIndex}`}><Thumbnail thumbnail={thumbnail} index={index + keyIndex} key={index + keyIndex++} setChosenImageIndex={props.setChosenImageIndex} /></Div>);
+          })}
+          {index + 7 < props.imageThumbnails.length && <Arrow className="fa-solid fa-arrow-down" key={"RightArrow"} onClick={() => {setIndex(index + 1)}} />/* If the starting index + 7 is < props.imageThumbnails.length, render a down arrow */}
+        </ImageThumbnails>
+      );
+    }
+  }
 
-  return (
-    <ImageThumbnails>
-      {index > 0 && <Arrow className="fa-solid fa-arrow-up" key={"LeftArrow"} onClick={() => {setIndex(index - 1)}} /> /* If the starting index is > 0, render an up arrow */}
-      {shown.map((thumbnail, keyIndex = 0) => {
-        // If the thumbnail is the chosen one, also render a box around it to indicate that it's the chosen one
-        if (keyIndex + index === props.chosenImageIndex) {
-          return (
-            <ChosenDiv key={"ChosenDiv"}><Thumbnail className="chosenImage" thumbnail={thumbnail} index={index + keyIndex} key={keyIndex++} setChosenImageIndex={props.setChosenImageIndex} /></ChosenDiv>
-          );
-        }
-        // Else just render the thumbnail itself
-        return (<Div key={`Div${keyIndex}`}><Thumbnail thumbnail={thumbnail} index={index + keyIndex} key={index + keyIndex++} setChosenImageIndex={props.setChosenImageIndex} /></Div>);
-      })}
-      {index + 7 < props.imageThumbnails.length && <Arrow className="fa-solid fa-arrow-down" key={"RightArrow"} onClick={() => {setIndex(index + 1)}} />/* If the starting index + 7 is < props.imageThumbnails.length, render a down arrow */}
-    </ImageThumbnails>
-  );
 }
 
 export default ThumbnailList;

--- a/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
@@ -16,7 +16,6 @@ var ThumbnailList = (props) => {
   // Whenever imageThumbnails changes, set the shown thumbnails
   useEffect(() => {
     setShown(props.imageThumbnails.slice(index, index + 7));
-    console.log('bah!!!!!');
   }, [index, props.imageThumbnails]);
 
   useEffect(() => {

--- a/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
@@ -17,7 +17,15 @@ var ThumbnailList = (props) => {
   useEffect(() => {
     setShown(props.imageThumbnails.slice(index, index + 7));
     console.log('bah!!!!!');
-  }, [index, props.imageThumbnails])
+  }, [index, props.imageThumbnails]);
+
+  useEffect(() => {
+    if (props.chosenImageIndex < index) {
+      setIndex(props.chosenImageIndex);
+    } else if (props.chosenImageIndex > index + 6) {
+      setIndex(props.chosenImageIndex - 6);
+    }
+  }, [props.chosenImageIndex]);
 
   // If the zoomed state is not active...
   if (!props.zoomed) {
@@ -29,7 +37,7 @@ var ThumbnailList = (props) => {
             // If the thumbnail is the chosen one, also render a box around it to indicate that it's the chosen one
             if (keyIndex + index === props.chosenImageIndex) {
               return (
-                <ChosenImageThumbnailIcon className="fa-solid fa-circle" index={index + keyIndex} onClick={() => {props.setChosenImageIndex(index + keyIndex)}} key={keyIndex} />
+                <ChosenImageThumbnailIcon className="fa-solid fa-circle" index={index + keyIndex} onClick={() => {props.setChosenImageIndex(index + keyIndex)}} key={`chosen${index + keyIndex}`} />
               );
             }
             // Else just render the thumbnail itself
@@ -46,11 +54,11 @@ var ThumbnailList = (props) => {
             // If the thumbnail is the chosen one, also render a box around it to indicate that it's the chosen one
             if (keyIndex + index === props.chosenImageIndex) {
               return (
-                <ChosenDiv key={"ChosenDiv"}><Thumbnail className="chosenImage" thumbnail={thumbnail} index={index + keyIndex} key={keyIndex++} setChosenImageIndex={props.setChosenImageIndex} /></ChosenDiv>
+                <ChosenDiv key={"ChosenDiv"}><Thumbnail className="chosenImage" thumbnail={thumbnail} index={index + keyIndex} key={`chosen${index + keyIndex}`} setChosenImageIndex={props.setChosenImageIndex} /></ChosenDiv>
               );
             }
             // Else just render the thumbnail itself
-            return (<Div key={`Div${keyIndex}`}><Thumbnail thumbnail={thumbnail} index={index + keyIndex} key={index + keyIndex++} setChosenImageIndex={props.setChosenImageIndex} /></Div>);
+            return (<Div key={`Div${keyIndex}`}><Thumbnail thumbnail={thumbnail} index={index + keyIndex} key={index + keyIndex} setChosenImageIndex={props.setChosenImageIndex} /></Div>);
           })}
           {index + 7 < props.imageThumbnails.length && <Arrow className="fa-solid fa-arrow-down" key={"RightArrow"} onClick={() => {setIndex(index + 1)}} />/* If the starting index + 7 is < props.imageThumbnails.length, render a down arrow */}
         </ImageThumbnails>

--- a/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
@@ -24,8 +24,7 @@ var ThumbnailList = (props) => {
     if (props.expanded) {
       return (
         <ImageThumbnailIconContainer>
-          {index > 0 && <Arrow className="fa-solid fa-arrow-up" key={"LeftArrow"} onClick={() => {setIndex(index - 1)}} /> /* If the starting index is > 0, render an up arrow */}
-          {shown.map((thumbnail, keyIndex = 0) => {
+          {props.imageThumbnails.map((thumbnail, keyIndex = 0) => {
             // If the thumbnail is the chosen one, also render a box around it to indicate that it's the chosen one
             if (keyIndex + index === props.chosenImageIndex) {
               return (
@@ -35,7 +34,6 @@ var ThumbnailList = (props) => {
             // Else just render the thumbnail itself
             return (<ImageThumbnailIcon className="fa-solid fa-circle" index={index + keyIndex} onClick={() => {props.setChosenImageIndex(index + keyIndex)}} key={index + keyIndex}/>);
           })}
-          {index + 7 < props.imageThumbnails.length && <Arrow className="fa-solid fa-arrow-down" key={"RightArrow"} onClick={() => {setIndex(index + 1)}} />/* If the starting index + 7 is < props.imageThumbnails.length, render a down arrow */}
         </ImageThumbnailIconContainer>
       );
     // Else the view is not expanded so render the default Image Thumbnail List

--- a/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
@@ -16,6 +16,7 @@ var ThumbnailList = (props) => {
   // Whenever imageThumbnails changes, set the shown thumbnails
   useEffect(() => {
     setShown(props.imageThumbnails.slice(index, index + 7));
+    console.log('bah!!!!!');
   }, [index, props.imageThumbnails])
 
   // If the zoomed state is not active...

--- a/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ThumbnailList.jsx
@@ -2,7 +2,7 @@
 
 // Import stuff
 import React, { useState, useEffect } from 'react';
-import { ImageThumbnails, Div, ChosenDiv, Arrow, ImageThumbnailIconContainer, ImageThumbnailIcon } from '../StyledComponents/ImageGallery/ImageThumbnails.jsx';
+import { ImageThumbnails, Div, ChosenDiv, Arrow, ImageThumbnailIconContainer, ImageThumbnailIcon, ChosenImageThumbnailIcon } from '../StyledComponents/ImageGallery/ImageThumbnails.jsx';
 import Thumbnail from './Thumbnail.jsx';
 
 // The list component itself
@@ -24,7 +24,18 @@ var ThumbnailList = (props) => {
     if (props.expanded) {
       return (
         <ImageThumbnailIconContainer>
-          <ImageThumbnailIcon className="fa-solid fa-circle" />
+          {index > 0 && <Arrow className="fa-solid fa-arrow-up" key={"LeftArrow"} onClick={() => {setIndex(index - 1)}} /> /* If the starting index is > 0, render an up arrow */}
+          {shown.map((thumbnail, keyIndex = 0) => {
+            // If the thumbnail is the chosen one, also render a box around it to indicate that it's the chosen one
+            if (keyIndex + index === props.chosenImageIndex) {
+              return (
+                <ChosenImageThumbnailIcon className="fa-solid fa-circle" index={index + keyIndex} onClick={() => {props.setChosenImageIndex(index + keyIndex)}} key={keyIndex} />
+              );
+            }
+            // Else just render the thumbnail itself
+            return (<ImageThumbnailIcon className="fa-solid fa-circle" index={index + keyIndex} onClick={() => {props.setChosenImageIndex(index + keyIndex)}} key={index + keyIndex}/>);
+          })}
+          {index + 7 < props.imageThumbnails.length && <Arrow className="fa-solid fa-arrow-down" key={"RightArrow"} onClick={() => {setIndex(index + 1)}} />/* If the starting index + 7 is < props.imageThumbnails.length, render a down arrow */}
         </ImageThumbnailIconContainer>
       );
     // Else the view is not expanded so render the default Image Thumbnail List

--- a/client/src/Components/ProductOverview/StyledComponents/Containers.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/Containers.jsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 const ProductOverviewContainer = styled.section`
   display: flex;
   flex-direction: row;
+  min-width: 1353px;
 `;
 
 // Image Gallery container
@@ -99,6 +100,7 @@ const QuantityDropdownContainer = styled.section`
 const ProductInformationDescription = styled.section`
   display: flex;
   flex-direction: row;
+  min-width: 1353px;
   background-color: #607b7d;
   border: solid 3px;
   border-top: 0;

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageThumbnails.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageThumbnails.jsx
@@ -85,13 +85,11 @@ const ImageThumbnailIconContainer = styled.section`
 
 // An image thumbnail but in icon form (for expanded view)
 const ImageThumbnailIcon = styled.i`
-  object-fit: cover;
+  object-fit: fill;
   overflow: hidden;
-  width: 10px;
-  height: 10px;
+  width: 20px;
+  height: 20px;
   color: #828e82;
-  border-radius: 50%;
-
   :hover {
     cursor: pointer;
     color: #EF8354;
@@ -99,5 +97,14 @@ const ImageThumbnailIcon = styled.i`
   z-index: 22;
 `;
 
+const ChosenImageThumbnailIcon = styled.i`
+  object-fit: fill;
+  overflow: hidden;
+  width: 20px;
+  height: 20px;
+  color: #EF8354;
+  z-index: 22;
+`;
+
 // Export the styled components
-export { ImageThumbnails, ThumbnailImage, Div, ChosenDiv, Arrow, ImageThumbnailIconContainer, ImageThumbnailIcon };
+export { ImageThumbnails, ThumbnailImage, Div, ChosenDiv, Arrow, ImageThumbnailIconContainer, ImageThumbnailIcon, ChosenImageThumbnailIcon };

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageThumbnails.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageThumbnails.jsx
@@ -71,5 +71,33 @@ const Arrow = styled.i`
   }
 `;
 
+// Container to hold the Image Thumbnails in icon form (for expanded view)
+const ImageThumbnailIconContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 12px;
+  background-color: #3a606e;
+  border-radius: 10px;
+  z-index: 21;
+`;
+
+// An image thumbnail but in icon form (for expanded view)
+const ImageThumbnailIcon = styled.i`
+  object-fit: cover;
+  overflow: hidden;
+  width: 10px;
+  height: 10px;
+  color: #828e82;
+  border-radius: 50%;
+
+  :hover {
+    cursor: pointer;
+    color: #EF8354;
+  }
+  z-index: 22;
+`;
+
 // Export the styled components
-export { ImageThumbnails, ThumbnailImage, Div, ChosenDiv, Arrow };
+export { ImageThumbnails, ThumbnailImage, Div, ChosenDiv, Arrow, ImageThumbnailIconContainer, ImageThumbnailIcon };

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
@@ -27,11 +27,27 @@ const Magnifier = styled.div`
   pointer-events: none;
   height: 740px;
   width: 100vw;
+  top: 0;
+  left: 0;
   background-image: url(${(props) => props.imageUrl});
   background-repeat: no-repeat;
   background-size: 100vw 1850px;
-  background-position-x: ${(props) => {return (props.x * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2)}}px;
-  background-position-y: ${(props) => {return (props.y * (-1) * props.magnifier + 740/2)}}px;
+  background-position-x: ${(props) => {
+                            var zoomPosition = props.x * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2;
+                            if (zoomPosition >= (100/document.documentElement.clientWidth)) {
+                              return zoomPosition;
+                            } else {
+                              return 0;
+                            }
+                          }}px;
+  background-position-y: ${(props) => {
+                            var zoomPosition = props.y * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2;
+                            if (zoomPosition <= 0) {
+                              return zoomPosition;
+                            } else {
+                              return 0;
+                            }
+                          }}px;
   border: solid 3px black;
   z-index: 25;
 `;

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
@@ -31,10 +31,10 @@ const Magnifier = styled.div`
   left: 0;
   background-image: url(${(props) => props.imageUrl});
   background-repeat: no-repeat;
-  background-size: 100vw 1850px;
+  background-size: ${(props) => {return (props.imageWidth * props.magnifier)}}px ${(props) => {return (props.imageHeight * props.magnifier)}}px;
   background-position-x: ${(props) => {
                             var zoomPosition = props.x * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2;
-                            if (zoomPosition >= (100/document.documentElement.clientWidth)) {
+                            if (zoomPosition >= 0) {
                               return zoomPosition;
                             } else {
                               return 0;
@@ -42,10 +42,11 @@ const Magnifier = styled.div`
                           }}px;
   background-position-y: ${(props) => {
                             var zoomPosition = props.y * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2;
-                            if (zoomPosition <= 0) {
+                            console.log(zoomPosition);
+                            if (zoomPosition >=  ((props.magnifier - 1) * -1 * props.imageHeight)) {
                               return zoomPosition;
                             } else {
-                              return 0;
+                              return (props.magnifier - 1) * -1 * props.imageHeight;
                             }
                           }}px;
   border: solid 3px black;

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
@@ -34,16 +34,28 @@ const Magnifier = styled.div`
   background-size: ${(props) => {return (props.imageWidth * props.magnifier)}}px ${(props) => {return (props.imageHeight * props.magnifier)}}px;
   background-position-x: ${(props) => {
                             var zoomPosition = props.x * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2;
-
-                            if (zoomPosition >= (-1 * props.imageWidth)) {
+                            console.log(zoomPosition, props.imageWidth);
+                            // If the width of the image is smaller than the size of the viewport, just render the whole width
+                            if ((props.imageWidth * props.magnifier) <  (100/document.documentElement.clientWidth)) {
+                              return 0;
+                            }
+                            if (zoomPosition - props.imageWidth >= 0) {
+                              console.log('in up');
                               return zoomPosition;
                             } else {
-                              return (-1 * props.imageWidth);
+                              console.log('in down');
+                              return props.imageWidth * (props.magnifier - 1) + (100/document.documentElement.clientWidth) + zoomPosition - props.imageWidth*.75;
                             }
+                            // if (zoomPosition > props.imageWidth * -1 * (props.magnifier - 1)) {
+                            //   return zoomPosition;
+                            // } else {
+                            //   console.log('RAH!', props.imageWidth * -1 * (props.magnifier) + (100/document.documentElement.clientWidth));
+                            //   return props.imageWidth * -1 * (props.magnifier) + (100/document.documentElement.clientWidth) - zoomPosition;
+                            // }
+                            // return props.imageWidth * (props.magnifier - 1) + (100/document.documentElement.clientWidth) + zoomPosition;
                           }}px;
   background-position-y: ${(props) => {
                             var zoomPosition = props.y * (-1) * props.magnifier + 740/2;
-                            console.log(zoomPosition, (props.magnifier - 1) * -1 * props.imageHeight);
                             if (zoomPosition > 0) {
                               return 0;
                             } else if (zoomPosition >= ((props.magnifier - 1) * -1 * props.imageHeight)) {

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
@@ -34,7 +34,8 @@ const Magnifier = styled.div`
   background-size: ${(props) => {return (props.imageWidth * props.magnifier)}}px ${(props) => {return (props.imageHeight * props.magnifier)}}px;
   background-position-x: ${(props) => {
                             var zoomPosition = props.x * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2;
-                            if (zoomPosition >= 0) {
+                            console.log(zoomPosition);
+                            if (zoomPosition >= ((props.magnifier - 1) * -1 * props.imageWidth)) {
                               return zoomPosition;
                             } else {
                               return 0;
@@ -42,8 +43,7 @@ const Magnifier = styled.div`
                           }}px;
   background-position-y: ${(props) => {
                             var zoomPosition = props.y * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2;
-                            console.log(zoomPosition);
-                            if (zoomPosition >=  ((props.magnifier - 1) * -1 * props.imageHeight)) {
+                            if (zoomPosition >= ((props.magnifier - 1) * -1 * props.imageHeight)) {
                               return zoomPosition;
                             } else {
                               return (props.magnifier - 1) * -1 * props.imageHeight;

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
@@ -1,0 +1,36 @@
+// The Image zoom/magnifier when the main image is in zoom mode
+
+// Import any relevant methods from the styled-components library
+import styled from 'styled-components';
+
+// Container to hold everything in the ImageZoom component
+const ImageZoomContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  position: relative;
+  width: 100vw;
+  height: 740px;
+`;
+
+// The image being zoomed
+const ZoomedImage = styled.img`
+  overflow: hidden;
+  z-index: 16;
+`;
+
+// The magnifying div
+const Magnifier = styled.div`
+  position: absolute;
+  pointer-events: none;
+  height: 1850px;
+  width: 250vw;
+  background-image: url(${(props) => props.imageUrl});
+  background-repeat: no-repeat;
+  background-size: 250vw 1850px;
+  background-position-x: ${(props) => {return (props.x * (-1) * props.magnifier + (250/document.documentElement.clientWidth)/2)}}px;
+  background-position-y: ${(props) => {return (props.y * (-1) * props.magnifier + 1850/2)}}px;
+  border: solid 3px black;
+  z-index: 25;
+`;
+
+export { ImageZoomContainer, ZoomedImage, Magnifier };

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
@@ -34,16 +34,19 @@ const Magnifier = styled.div`
   background-size: ${(props) => {return (props.imageWidth * props.magnifier)}}px ${(props) => {return (props.imageHeight * props.magnifier)}}px;
   background-position-x: ${(props) => {
                             var zoomPosition = props.x * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2;
-                            console.log(zoomPosition);
-                            if (zoomPosition >= ((props.magnifier - 1) * -1 * props.imageWidth)) {
+
+                            if (zoomPosition >= (-1 * props.imageWidth)) {
                               return zoomPosition;
                             } else {
-                              return 0;
+                              return (-1 * props.imageWidth);
                             }
                           }}px;
   background-position-y: ${(props) => {
-                            var zoomPosition = props.y * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2;
-                            if (zoomPosition >= ((props.magnifier - 1) * -1 * props.imageHeight)) {
+                            var zoomPosition = props.y * (-1) * props.magnifier + 740/2;
+                            console.log(zoomPosition, (props.magnifier - 1) * -1 * props.imageHeight);
+                            if (zoomPosition > 0) {
+                              return 0;
+                            } else if (zoomPosition >= ((props.magnifier - 1) * -1 * props.imageHeight)) {
                               return zoomPosition;
                             } else {
                               return (props.magnifier - 1) * -1 * props.imageHeight;

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
@@ -16,19 +16,22 @@ const ImageZoomContainer = styled.div`
 const ZoomedImage = styled.img`
   overflow: hidden;
   z-index: 16;
+  :hover {
+    cursor: vertical-text;
+  }
 `;
 
 // The magnifying div
 const Magnifier = styled.div`
   position: absolute;
   pointer-events: none;
-  height: 1850px;
-  width: 250vw;
+  height: 740px;
+  width: 100vw;
   background-image: url(${(props) => props.imageUrl});
   background-repeat: no-repeat;
-  background-size: 250vw 1850px;
-  background-position-x: ${(props) => {return (props.x * (-1) * props.magnifier + (250/document.documentElement.clientWidth)/2)}}px;
-  background-position-y: ${(props) => {return (props.y * (-1) * props.magnifier + 1850/2)}}px;
+  background-size: 100vw 1850px;
+  background-position-x: ${(props) => {return (props.x * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2)}}px;
+  background-position-y: ${(props) => {return (props.y * (-1) * props.magnifier + 740/2)}}px;
   border: solid 3px black;
   z-index: 25;
 `;

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
@@ -34,25 +34,10 @@ const Magnifier = styled.div`
   background-size: ${(props) => {return (props.imageWidth * props.magnifier)}}px ${(props) => {return (props.imageHeight * props.magnifier)}}px;
   background-position-x: ${(props) => {
                             var zoomPosition = props.x * (-1) * props.magnifier + (100/document.documentElement.clientWidth)/2;
-                            console.log(zoomPosition, props.imageWidth);
-                            // If the width of the image is smaller than the size of the viewport, just render the whole width
-                            if ((props.imageWidth * props.magnifier) <  (100/document.documentElement.clientWidth)) {
-                              return 0;
-                            }
-                            if (zoomPosition - props.imageWidth >= 0) {
-                              console.log('in up');
-                              return zoomPosition;
-                            } else {
-                              console.log('in down');
-                              return props.imageWidth * (props.magnifier - 1) + (100/document.documentElement.clientWidth) + zoomPosition - props.imageWidth*.75;
-                            }
-                            // if (zoomPosition > props.imageWidth * -1 * (props.magnifier - 1)) {
-                            //   return zoomPosition;
-                            // } else {
-                            //   console.log('RAH!', props.imageWidth * -1 * (props.magnifier) + (100/document.documentElement.clientWidth));
-                            //   return props.imageWidth * -1 * (props.magnifier) + (100/document.documentElement.clientWidth) - zoomPosition;
+                            // if ((zoomPosition < -1 * props.imageWidth * .75)) {
+                            //   return 0;
                             // }
-                            // return props.imageWidth * (props.magnifier - 1) + (100/document.documentElement.clientWidth) + zoomPosition;
+                            return props.imageWidth * (props.magnifier - 1) + (100/document.documentElement.clientWidth) + zoomPosition - props.imageWidth*.75;
                           }}px;
   background-position-y: ${(props) => {
                             var zoomPosition = props.y * (-1) * props.magnifier + 740/2;
@@ -64,6 +49,7 @@ const Magnifier = styled.div`
                               return (props.magnifier - 1) * -1 * props.imageHeight;
                             }
                           }}px;
+  background-color: #828e82;
   border: solid 3px black;
   z-index: 25;
 `;

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 const Image = styled.img`
   object-fit: cover;
   overflow: hidden;
-  z-index: 1;
+  z-index: 16;
 `;
 
 // The Main Image, default view
@@ -45,7 +45,7 @@ const LeftArrow = styled.i`
   border: solid;
   border-color: black;
   border-radius: 10%;
-  z-index: 2;
+  z-index: 20;
   :hover {
     cursor: pointer;
     background-color: #EF8354;
@@ -65,7 +65,7 @@ const RightArrow = styled.i`
   border: solid;
   border-color: black;
   border-radius: 10%;
-  z-index: 2;
+  z-index: 20;
   :hover {
     cursor: pointer;
     background-color: #EF8354;
@@ -85,7 +85,7 @@ const FullScreen = styled.i`
   border: solid;
   border-color: black;
   border-radius: 10%;
-  z-index: 2;
+  z-index: 20;
   :hover {
     cursor: pointer;
     background-color: #EF8354;
@@ -94,9 +94,16 @@ const FullScreen = styled.i`
 
 // The Main Image, expanded view
 const ExpandedView = styled.div`
+  display: flex;
+  justify-content: center;
+  position: absolute;
   width: 100vw;
   height: 740px;
   background-color: black;
+  z-index: 15;
+  border: solid 3px;
+  border-radius: 10px 10px 0 0;
+  border-color: #120309;
 `;
 
 // An overlay div that'll go over the Expanded View div; this also contains the Left and Right Arrows
@@ -107,5 +114,12 @@ const ExpandedOverlay = styled.div`
   background-color: #828e82;
 `;
 
+// A wrapper that just has position: relative
+const RelativeWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: row;
+`;
+
 // Export the styled components
-export { Image, DefaultView, DefaultOverlay, ExpandedOverlay, LeftArrow, RightArrow, FullScreen, ExpandedView };
+export { Image, DefaultView, DefaultOverlay, LeftArrow, RightArrow, FullScreen, ExpandedView, ExpandedOverlay, RelativeWrapper };

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
@@ -104,6 +104,9 @@ const ExpandedView = styled.div`
   border: solid 3px;
   border-radius: 10px 10px 0 0;
   border-color: #120309;
+  :hover {
+    cursor: crosshair;
+  }
 `;
 
 // An overlay div that'll go over the Expanded View div; this also contains the Left and Right Arrows

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
@@ -26,7 +26,7 @@ const DefaultView = styled.div`
 `;
 
 // An overlay div that'll go over the Default View div; this contains the Left and Right Arrows
-const Overlay = styled.div`
+const DefaultOverlay = styled.div`
   position: absolute;
   width: 718px;
   height: 740px;
@@ -100,4 +100,4 @@ const ExpandedView = styled.div`
 `;
 
 // Export the styled components
-export { Image, DefaultView, Overlay, LeftArrow, RightArrow, FullScreen, ExpandedView };
+export { Image, DefaultView, DefaultOverlay, LeftArrow, RightArrow, FullScreen, ExpandedView };

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
@@ -94,10 +94,18 @@ const FullScreen = styled.i`
 
 // The Main Image, expanded view
 const ExpandedView = styled.div`
-  width: 1000px;
-  height: 628px;
+  width: 100vw;
+  height: 740px;
   background-color: black;
 `;
 
+// An overlay div that'll go over the Expanded View div; this also contains the Left and Right Arrows
+const ExpandedOverlay = styled.div`
+  position: absolute;
+  width: 100vw;
+  height: 740px;
+  background-color: #828e82;
+`;
+
 // Export the styled components
-export { Image, DefaultView, DefaultOverlay, LeftArrow, RightArrow, FullScreen, ExpandedView };
+export { Image, DefaultView, DefaultOverlay, ExpandedOverlay, LeftArrow, RightArrow, FullScreen, ExpandedView };


### PR DESCRIPTION
Big pull request here that finalizes the functionality of the Product Overview widget.

- refactor: rename some components in the Main Image and Gallery components for clarity when implementing expanded and zoomed views
- feat: implement expanded view of main image; image thumbnail icons dynamically render based on the main image view
- bugfix: fix issue where components with duplicate keys would be generated when scrolling through main images using the left/right arrows
- feat: implement zoomed view on main image
The horizontal panning on the zoomed view is not perfect, but it is the best that I could muster at this point in time. Perhaps later I will attempt to improve it.