### PR TITLE
bugfixes: various Overview widget bugfixes

### DIFF
--- a/client/src/Components/ProductOverview/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/ImageGallery/ImageZoom.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ImageZoomContainer, Magnifier, ZoomedImage } from '../StyledComponents/ImageGallery/ImageZoom.jsx';
+import { ImageZoomContainer, ImageZoomOverlay, Magnifier, ZoomedImage } from '../StyledComponents/ImageGallery/ImageZoom.jsx';
 
 const ImageZoom = (props) => {
 
@@ -34,13 +34,15 @@ const ImageZoom = (props) => {
 
   return (
     <ImageZoomContainer>
-      <ZoomedImage src={props.imageUrl}
-        onMouseEnter={(event) => { handleMouseEnter(event); }}
-        onMouseLeave={() => { setMagnifying(false); }}
-        onMouseMove={(event) => { handleMouseMove(event) }}
-        onClick={() => { props.setZoomed(false); }}
-      />
-      {magnifying && <Magnifier imageUrl={props.imageUrl} magnifier={magnifier} x={x} y={y} imageWidth={imageWidth} imageHeight={imageHeight} />}
+      <ImageZoomOverlay>
+        <ZoomedImage src={props.imageUrl}
+          onMouseEnter={(event) => { handleMouseEnter(event); }}
+          onMouseLeave={() => { setMagnifying(false); }}
+          onMouseMove={(event) => { handleMouseMove(event) }}
+          onClick={() => { props.setZoomed(false); }}
+        />
+        {magnifying && <Magnifier imageUrl={props.imageUrl} magnifier={magnifier} x={x} y={y} imageWidth={imageWidth} imageHeight={imageHeight} />}
+      </ImageZoomOverlay>
     </ImageZoomContainer>
   );
 }

--- a/client/src/Components/ProductOverview/ProductInformation/AddToCart.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/AddToCart.jsx
@@ -74,7 +74,7 @@ var AddToCart = (props) => {
       <SizeAndCountContainer>
         <SizeDropdownContainer>
           {clickedWithoutSize && <WarningText id="sizeWarning">Please select size</WarningText>}
-          <SizeDropdown name="size" id="size-select" onChange={(event) => {setChosenSize(event.target.value); setClickedWithoutSize(false);}}>
+          <SizeDropdown name="size" id="size-select" onChange={(event) => {setChosenSize(event.target.value); setClickedWithoutSize(false); setChosenQuantity("1");}}>
             <option value="">Select Size</option>
             {/* For each sku_id, add a size */}
             {skus.map((sku_id, index) => {
@@ -86,7 +86,7 @@ var AddToCart = (props) => {
         </SizeDropdownContainer>
         <QuantityDropdownContainer>
           {clickedWithoutQuantity && <WarningText id="quantityWarning">Please select quantity</WarningText>}
-          <QuantityDropdown name="quantity" id="quantity-select" disabled={!chosenSize} onChange={(event) => {setChosenQuantity(event.target.value); setClickedWithoutQuantity(false);}}>
+          <QuantityDropdown name="quantity" id="quantity-select" disabled={!chosenSize} onChange={(event) => {setChosenQuantity(event.target.value); setClickedWithoutQuantity(false);}} value={chosenQuantity}>
             <option value="0">-</option>
             {/* Add options for the quantity based on how many are available for the selected size */}
             {quantityOptions.map((quantity) => {

--- a/client/src/Components/ProductOverview/ProductInformation/AddToCart.jsx
+++ b/client/src/Components/ProductOverview/ProductInformation/AddToCart.jsx
@@ -78,7 +78,7 @@ var AddToCart = (props) => {
             <option value="">Select Size</option>
             {/* For each sku_id, add a size */}
             {skus.map((sku_id, index) => {
-              if (style.skus[sku_id.toString()]) {
+              if (style.skus[sku_id.toString()] && style.skus[sku_id.toString()].quantity !== 0) {
                 return <option value={sku_id} key={`size${index}`}>{style.skus[sku_id.toString()].size}</option>
               }
             })}
@@ -86,7 +86,7 @@ var AddToCart = (props) => {
         </SizeDropdownContainer>
         <QuantityDropdownContainer>
           {clickedWithoutQuantity && <WarningText id="quantityWarning">Please select quantity</WarningText>}
-          <QuantityDropdown name="quantity" id="quantity-select" disabled={!chosenSize} value="1" onChange={(event) => {setChosenQuantity(event.target.value); setClickedWithoutQuantity(false);}}>
+          <QuantityDropdown name="quantity" id="quantity-select" disabled={!chosenSize} onChange={(event) => {setChosenQuantity(event.target.value); setClickedWithoutQuantity(false);}}>
             <option value="0">-</option>
             {/* Add options for the quantity based on how many are available for the selected size */}
             {quantityOptions.map((quantity) => {

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/ImageZoom.jsx
@@ -4,11 +4,26 @@
 import styled from 'styled-components';
 
 // Container to hold everything in the ImageZoom component
-const ImageZoomContainer = styled.div`
+const ImageZoomContainer = styled.section`
   display: flex;
   justify-content: center;
-  position: relative;
-  width: 100vw;
+  position: absolute;
+  width: 1353px;
+  height: 740px;
+  background-color: #828e82;
+  z-index: 15;
+  border: solid 3px;
+  border-radius: 10px 10px 10px 10px;
+  border-color: #120309;
+`;
+
+// Overlay that hold image zoom (magnifier)
+const ImageZoomOverlay = styled.div`
+  display: flex;
+  justify-content: center;
+  position: absolute;
+  z-index: 15;
+  width: 1353px;
   height: 740px;
 `;
 
@@ -26,7 +41,7 @@ const Magnifier = styled.div`
   position: absolute;
   pointer-events: none;
   height: 740px;
-  width: 100vw;
+  width: 1353px;
   top: 0;
   left: 0;
   background-image: url(${(props) => props.imageUrl});
@@ -50,8 +65,7 @@ const Magnifier = styled.div`
                             }
                           }}px;
   background-color: #828e82;
-  border: solid 3px black;
   z-index: 25;
 `;
 
-export { ImageZoomContainer, ZoomedImage, Magnifier };
+export { ImageZoomContainer, ImageZoomOverlay, ZoomedImage, Magnifier };

--- a/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
+++ b/client/src/Components/ProductOverview/StyledComponents/ImageGallery/MainImage.jsx
@@ -97,7 +97,7 @@ const ExpandedView = styled.div`
   display: flex;
   justify-content: center;
   position: absolute;
-  width: 100vw;
+  width: 1353px;
   height: 740px;
   background-color: black;
   z-index: 15;
@@ -112,7 +112,7 @@ const ExpandedView = styled.div`
 // An overlay div that'll go over the Expanded View div; this also contains the Left and Right Arrows
 const ExpandedOverlay = styled.div`
   position: absolute;
-  width: 100vw;
+  width: 1353px;
   height: 740px;
   background-color: #828e82;
 `;


### PR DESCRIPTION
fix the following bugs:

- quantity-select options are no longer locked to 1 after selecting a size
- Main Image expanded view (both default expanded mode and zoom mode) width is now consistent and does not spill over the widget, and zoom mode no longer makes the Product Information section appear on the far right

also implement the following to further match Business Requirements Document expectations:

- refactor: size options that correspond to sizes that have no stock no longer appear in the size-select 

I fiddled and converted some sizes from using `vw` units to now be locked at a set amount of `px`. Please check this commit on your local machine by doing `git fetch origin overviewBugfixes` and `git checkout overviewBugfixes` before reviewing the pull request, just in case things turn out to be wonky on your browser.
Edit: And play with the zoom functionality for a second or two to make sure it actually works.